### PR TITLE
When the keyboard is connected for the first time and create layer, the layer is not changing when clicking

### DIFF
--- a/src/components/keyboard/Keyboard.tsx
+++ b/src/components/keyboard/Keyboard.tsx
@@ -37,12 +37,11 @@ export default function Keyboard({
 	useEffect( () => {
 		if ( !keymap?.layers ) return
 
-		const layer = keymap.layers.find(layer => layer.id === selectedLayerIndex)
+		console.log('Keymap changed, selectedLayerIndex:', selectedLayerIndex, 'layers count:', keymap?.layers.length)
 
-		console.log('Keymap changed, current layer:', layer, 'layers:', keymap?.layers)
-
-		if (!layer) {
-			setSelectedLayerIndex(keymap.layers[0].id)
+		// Validate that selectedLayerIndex is within bounds of the layers array
+		if ( selectedLayerIndex < 0 || selectedLayerIndex >= keymap.layers.length ) {
+			setSelectedLayerIndex( 0 )
 		}
 
 	}, [ keymap, selectedLayerIndex, setSelectedLayerIndex ] )

--- a/src/components/keyboard/LayerPicker.tsx
+++ b/src/components/keyboard/LayerPicker.tsx
@@ -186,9 +186,10 @@ export const LayerPicker = ( {
 	useEffect( () => {
 		if ( !keymap?.layers ) return
 
-		const layer = keymap.layers.find( layer => layer.id === selectedLayerIndex )
-
-		if ( !layer ) setSelectedLayerIndex( keymap.layers[0].id )
+		// Validate that selectedLayerIndex is within bounds of the layers array
+		if ( selectedLayerIndex < 0 || selectedLayerIndex >= keymap.layers.length ) {
+			setSelectedLayerIndex( 0 )
+		}
 
 	}, [ keymap, selectedLayerIndex, setSelectedKey, setSelectedLayerIndex ] )
 


### PR DESCRIPTION
## Summary
## Summary

When connecting a ZMK-compatible keyboard that hasn't been connected for a while (or is connecting for the first time), creating a new layer and attempting to switch to it does not work. The keyboard view refreshes but remains on the first layer instead of switching to the newly created layer.

## Environment

- **Browser:** Chrome
- **Keyboard:** ZMK-compatible keyboard
- **Platform:** ZMK Studio

## Steps to Reproduce

1. Ensure the keyboard has not been connected to ZMK Studio recently (or is connecting for the first time)
2. Connect the keyboard to ZMK Studio
3. Create a new layer using the "Add Layer" functionality
4. Click on the newly created layer to switch to it

## Expected Behavior

After creating a new layer, clicking on it should immediately switch the keyboard view to display that layer's keymap.

## Actual Behavior

After creating a new layer and clicking on it:
- The keyboard view appears to refresh
- The view remains on the first layer (Layer 0)
- The newly created layer is not selected/displayed

## Workaround

Refresh the browser page, then reconnect to the keyboard. After doing this, layer switching works correctly for all layers including the newly created one.

## Additional Context

- No errors appear in the browser console when this issue occurs
- This only affects newly created layers during the initial connection session
- Existing layers and subsequent connections work correctly after a page refresh
- The issue seems to be related to state synchronization on first connection

## Plan
# Implementation Plan (Lite)

## Task
When the keyboard is connected for the first time and create layer, the layer is not changing when clicking

## Description
## Summary

When connecting a ZMK-compatible keyboard that hasn't been connected for a while (or is connecting for the first time), creating a new layer and attempting to switch to it does not work. The keyboard view refreshes but remains on the first layer instead of switching to the newly created layer.

## Environment

- **Browser:** Chrome
- **Keyboard:** ZMK-compatible keyboard
- **Platform:** ZMK Studio

## Steps to Reproduce

1. Ensure the keyboard has not been connected to ZMK Studio recently (or is connecting for the first time)
2. Connect the keyboard to ZMK Studio
3. Create a new layer using the "Add Layer" functionality
4. Click on the newly created layer to switch to it

## Expected Behavior

After creating a new layer, clicking on it should immediately switch the keyboard view to display that layer's keymap.

## Actual Behavior

After creating a new layer and clicking on it:
- The keyboard view appears to refresh
- The view remains on the first layer (Layer 0)
- The newly created layer is not selected/displayed

## Workaround

Refresh the browser page, then reconnect to the keyboard. After doing this, layer switching works correctly for all layers including the newly created one.

## Additional Context

- No errors appear in the browser console when this issue occurs
- This only affects newly created layers during the initial connection session
- Existing layers and subsequent connections work correctly after a page refresh
- The issue seems to be related to state synchronization on first connection

## Approach
1. Analyze the requirements
2. Identify files to modify
3. Implement changes
4. Run verification commands
5. Commit and push

## Commands to Run
- None specified

## Testing
All checks passed

---
Closes #11

_Automated by Patchwork_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures layer selection stays valid after initial connection and layer creation.
> 
> - Add bounds check for `selectedLayerIndex` in `Keyboard.tsx` and `LayerPicker.tsx`; reset to `0` if index is out of range of `keymap.layers`
> - Remove reliance on finding layer by id; use index validation instead
> - Add debug logging in `Keyboard.tsx` for keymap/layer state changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6306e579d58cd4cdbdd78f6efebf9fcf56bc82d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->