### PR TITLE
Detect and parse hold-tap bindings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,8 @@
                 "tailwindcss": "^4.1.18",
                 "tw-animate-css": "^1.4.0",
                 "typescript": "^5.9.3",
-                "vite": "^7.2.6"
+                "vite": "^7.2.6",
+                "vitest": "^3.2.4"
             },
             "optionalDependencies": {
                 "@esbuild/darwin-arm64": "0.23.0",
@@ -6894,6 +6895,43 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vitest/mocker": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+            "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.2.4",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/@vitest/pretty-format": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
@@ -6902,6 +6940,36 @@
             "license": "MIT",
             "dependencies": {
                 "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+            "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.2.4",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+            "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.4",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
@@ -8723,6 +8791,7 @@
             "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "app-builder-lib": "26.8.1",
                 "builder-util": "26.8.1",
@@ -9291,6 +9360,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -9852,6 +9928,16 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/exponential-backoff": {
@@ -12689,6 +12775,13 @@
                 "node": "20 || >=22"
             }
         },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/pathval": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
@@ -13994,6 +14087,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -14137,6 +14237,13 @@
                 "node": "^18.17.0 || >=20.5.0"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/stat-mode": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -14146,6 +14253,13 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/std-env": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -14442,6 +14556,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-literal": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^9.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/sumchecker": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -14639,6 +14773,20 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -14653,6 +14801,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinypool": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
             }
         },
         "node_modules/tinyrainbow": {
@@ -15189,6 +15347,29 @@
                 }
             }
         },
+        "node_modules/vite-node": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
@@ -15646,6 +15827,79 @@
                 "@esbuild/win32-x64": "0.27.2"
             }
         },
+        "node_modules/vitest": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+            "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.4",
+                "@vitest/mocker": "3.2.4",
+                "@vitest/pretty-format": "^3.2.4",
+                "@vitest/runner": "3.2.4",
+                "@vitest/snapshot": "3.2.4",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.4",
+                "@vitest/ui": "3.2.4",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/wcwidth": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -15766,6 +16020,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
         "build:unpack": "npm run build && electron-builder --dir",
         "build:win": "npm run build && electron-builder --win",
         "build:mac": "electron-vite build && electron-builder --mac",
-        "build:linux": "electron-vite build && electron-builder --linux"
+        "build:linux": "electron-vite build && electron-builder --linux",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
@@ -107,7 +109,8 @@
         "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
-        "vite": "^7.2.6"
+        "vite": "^7.2.6",
+        "vitest": "^3.2.4"
     },
     "optionalDependencies": {
         "@esbuild/darwin-arm64": "0.23.0",

--- a/src/renderer/src/helpers/Behaviors.ts
+++ b/src/renderer/src/helpers/Behaviors.ts
@@ -4,6 +4,17 @@ import type { GetBehaviorDetailsResponse } from '@zmkfirmware/zmk-studio-ts-clie
 import useConnectionStore from '../stores/ConnectionStore.ts'
 import { callRemoteProcedureControl } from '@/services/CallRemoteProcedureControl.ts'
 
+// Re-export hold-tap utilities from the dedicated module
+export {
+    HoldTapType,
+    isHoldTapBinding,
+    parseHoldTapBinding,
+    getTapParam,
+    getHoldParam,
+    type HoldTapBinding,
+    type HoldTapDetectionResult,
+} from './HoldTapBindings'
+
 export type BehaviorMap = Record<number, GetBehaviorDetailsResponse>
 
 export function useBehaviors(): BehaviorMap {

--- a/src/renderer/src/helpers/HoldTapBindings.test.ts
+++ b/src/renderer/src/helpers/HoldTapBindings.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, expect } from 'vitest'
+import {
+    HoldTapType,
+    isHoldTapBinding,
+    parseHoldTapBinding,
+    getTapParam,
+    getHoldParam,
+    type BehaviorMapLike,
+    type BehaviorDetailsLike,
+    type BehaviorBindingLike,
+    type BehaviorParameterValueDescriptionLike,
+} from './HoldTapBindings'
+
+// Mock behavior data for testing
+const createMockBehavior = (
+    id: number,
+    displayName: string,
+    hasLayerParam: boolean = false,
+    hasTwoParams: boolean = true,
+): BehaviorDetailsLike => {
+    const param1: BehaviorParameterValueDescriptionLike[] =
+        hasTwoParams || hasLayerParam
+            ? [
+                  hasLayerParam
+                      ? { name: 'Layer', layerId: {} }
+                      : {
+                            name: 'Modifier',
+                            hidUsage: { keyboardMax: 255, consumerMax: 0 },
+                        },
+              ]
+            : []
+
+    const param2: BehaviorParameterValueDescriptionLike[] = hasTwoParams
+        ? [{ name: 'Key', hidUsage: { keyboardMax: 255, consumerMax: 0 } }]
+        : []
+
+    return {
+        id,
+        displayName,
+        metadata: [{ param1, param2 }],
+    }
+}
+
+const createMockBinding = (
+    behaviorId: number,
+    param1: number,
+    param2: number,
+): BehaviorBindingLike => ({
+    behaviorId,
+    param1,
+    param2,
+})
+
+const createBehaviorMap = (
+    map: Record<number, BehaviorDetailsLike>,
+): BehaviorMapLike => map
+
+describe('Hold-Tap Binding Detection and Parsing', () => {
+    describe('isHoldTapBinding', () => {
+        it('detects Layer-Tap from display name "Layer-Tap"', () => {
+            const behaviors = createBehaviorMap({
+                1: createMockBehavior(1, 'Layer-Tap', true, true),
+            })
+            const binding = createMockBinding(1, 2, 4) // layer 2, key A
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.LayerTap)
+        })
+
+        it('detects Layer-Tap from display name "lt"', () => {
+            const behaviors = createBehaviorMap({
+                1: createMockBehavior(1, 'lt', true, true),
+            })
+            const binding = createMockBinding(1, 1, 5)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.LayerTap)
+        })
+
+        it('detects Mod-Tap from display name "Mod-Tap"', () => {
+            const behaviors = createBehaviorMap({
+                2: createMockBehavior(2, 'Mod-Tap', false, true),
+            })
+            const binding = createMockBinding(2, 224, 4) // LeftCtrl, key A
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.ModTap)
+        })
+
+        it('detects Mod-Tap from display name "mt"', () => {
+            const behaviors = createBehaviorMap({
+                2: createMockBehavior(2, 'mt', false, true),
+            })
+            const binding = createMockBinding(2, 225, 6)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.ModTap)
+        })
+
+        it('detects Sticky Key from display name "Sticky Key"', () => {
+            const behaviors = createBehaviorMap({
+                3: createMockBehavior(3, 'Sticky Key', false, false),
+            })
+            const binding = createMockBinding(3, 225, 0) // LeftShift
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.StickyKey)
+        })
+
+        it('detects Sticky Key from display name "sk"', () => {
+            const behaviors = createBehaviorMap({
+                3: createMockBehavior(3, 'sk', false, false),
+            })
+            const binding = createMockBinding(3, 224, 0)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.StickyKey)
+        })
+
+        it('returns not hold-tap for unknown behavior', () => {
+            const behaviors = createBehaviorMap({})
+            const binding = createMockBinding(999, 0, 0)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(false)
+            expect(result.type).toBeNull()
+        })
+
+        it('returns not hold-tap for regular key press behavior', () => {
+            const behaviors = createBehaviorMap({
+                4: {
+                    id: 4,
+                    displayName: 'Key Press',
+                    metadata: [{ param1: [], param2: [] }],
+                },
+            })
+            const binding = createMockBinding(4, 0, 0)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(false)
+            expect(result.type).toBeNull()
+        })
+
+        it('detects custom hold-tap from metadata structure', () => {
+            const behaviors = createBehaviorMap({
+                5: createMockBehavior(5, 'my_custom_behavior', false, true),
+            })
+            const binding = createMockBinding(5, 1, 4)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.Custom)
+        })
+
+        it('detects layer-tap from metadata with layerId param', () => {
+            const behaviors = createBehaviorMap({
+                6: createMockBehavior(6, 'custom_layer_behavior', true, true),
+            })
+            const binding = createMockBinding(6, 3, 10)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.LayerTap)
+        })
+    })
+
+    describe('parseHoldTapBinding', () => {
+        it('parses Layer-Tap binding correctly', () => {
+            const behaviors = createBehaviorMap({
+                1: createMockBehavior(1, 'Layer-Tap', true, true),
+            })
+            const binding = createMockBinding(1, 2, 4) // layer 2, key A
+
+            const parsed = parseHoldTapBinding(binding, behaviors)
+
+            expect(parsed).not.toBeNull()
+            expect(parsed?.type).toBe(HoldTapType.LayerTap)
+            expect(parsed?.behaviorId).toBe(1)
+            expect(parsed?.holdParam).toBe(2)
+            expect(parsed?.tapParam).toBe(4)
+            expect(parsed?.hasTapAndHold).toBe(true)
+        })
+
+        it('parses Mod-Tap binding correctly', () => {
+            const behaviors = createBehaviorMap({
+                2: createMockBehavior(2, 'Mod-Tap', false, true),
+            })
+            const binding = createMockBinding(2, 224, 5) // LeftCtrl, key B
+
+            const parsed = parseHoldTapBinding(binding, behaviors)
+
+            expect(parsed).not.toBeNull()
+            expect(parsed?.type).toBe(HoldTapType.ModTap)
+            expect(parsed?.behaviorId).toBe(2)
+            expect(parsed?.holdParam).toBe(224)
+            expect(parsed?.tapParam).toBe(5)
+            expect(parsed?.hasTapAndHold).toBe(true)
+        })
+
+        it('parses Sticky Key binding correctly (single param)', () => {
+            const behaviors = createBehaviorMap({
+                3: createMockBehavior(3, 'Sticky Key', false, false),
+            })
+            const binding = createMockBinding(3, 225, 0) // LeftShift
+
+            const parsed = parseHoldTapBinding(binding, behaviors)
+
+            expect(parsed).not.toBeNull()
+            expect(parsed?.type).toBe(HoldTapType.StickyKey)
+            expect(parsed?.behaviorId).toBe(3)
+            expect(parsed?.holdParam).toBe(225)
+            expect(parsed?.tapParam).toBeUndefined()
+            expect(parsed?.hasTapAndHold).toBe(false)
+        })
+
+        it('returns null for non-hold-tap binding', () => {
+            const behaviors = createBehaviorMap({
+                4: {
+                    id: 4,
+                    displayName: 'Key Press',
+                    metadata: [{ param1: [], param2: [] }],
+                },
+            })
+            const binding = createMockBinding(4, 4, 0)
+
+            const parsed = parseHoldTapBinding(binding, behaviors)
+
+            expect(parsed).toBeNull()
+        })
+
+        it('returns null for unknown behavior', () => {
+            const behaviors = createBehaviorMap({})
+            const binding = createMockBinding(999, 1, 2)
+
+            const parsed = parseHoldTapBinding(binding, behaviors)
+
+            expect(parsed).toBeNull()
+        })
+    })
+
+    describe('getTapParam', () => {
+        it('returns tap param for Layer-Tap', () => {
+            const behaviors = createBehaviorMap({
+                1: createMockBehavior(1, 'Layer-Tap', true, true),
+            })
+            const binding = createMockBinding(1, 2, 4)
+
+            const tapParam = getTapParam(binding, behaviors)
+
+            expect(tapParam).toBe(4)
+        })
+
+        it('returns tap param for Mod-Tap', () => {
+            const behaviors = createBehaviorMap({
+                2: createMockBehavior(2, 'Mod-Tap', false, true),
+            })
+            const binding = createMockBinding(2, 224, 10)
+
+            const tapParam = getTapParam(binding, behaviors)
+
+            expect(tapParam).toBe(10)
+        })
+
+        it('returns undefined for Sticky Key (no tap param)', () => {
+            const behaviors = createBehaviorMap({
+                3: createMockBehavior(3, 'Sticky Key', false, false),
+            })
+            const binding = createMockBinding(3, 225, 0)
+
+            const tapParam = getTapParam(binding, behaviors)
+
+            expect(tapParam).toBeUndefined()
+        })
+
+        it('returns undefined for non-hold-tap', () => {
+            const behaviors = createBehaviorMap({
+                4: {
+                    id: 4,
+                    displayName: 'Key Press',
+                    metadata: [{ param1: [], param2: [] }],
+                },
+            })
+            const binding = createMockBinding(4, 4, 0)
+
+            const tapParam = getTapParam(binding, behaviors)
+
+            expect(tapParam).toBeUndefined()
+        })
+    })
+
+    describe('getHoldParam', () => {
+        it('returns hold param (layer) for Layer-Tap', () => {
+            const behaviors = createBehaviorMap({
+                1: createMockBehavior(1, 'Layer-Tap', true, true),
+            })
+            const binding = createMockBinding(1, 3, 4)
+
+            const holdParam = getHoldParam(binding, behaviors)
+
+            expect(holdParam).toBe(3)
+        })
+
+        it('returns hold param (modifier) for Mod-Tap', () => {
+            const behaviors = createBehaviorMap({
+                2: createMockBehavior(2, 'Mod-Tap', false, true),
+            })
+            const binding = createMockBinding(2, 226, 10) // LeftAlt
+
+            const holdParam = getHoldParam(binding, behaviors)
+
+            expect(holdParam).toBe(226)
+        })
+
+        it('returns hold param for Sticky Key', () => {
+            const behaviors = createBehaviorMap({
+                3: createMockBehavior(3, 'Sticky Key', false, false),
+            })
+            const binding = createMockBinding(3, 225, 0)
+
+            const holdParam = getHoldParam(binding, behaviors)
+
+            expect(holdParam).toBe(225)
+        })
+
+        it('returns undefined for non-hold-tap', () => {
+            const behaviors = createBehaviorMap({
+                4: {
+                    id: 4,
+                    displayName: 'Key Press',
+                    metadata: [{ param1: [], param2: [] }],
+                },
+            })
+            const binding = createMockBinding(4, 4, 0)
+
+            const holdParam = getHoldParam(binding, behaviors)
+
+            expect(holdParam).toBeUndefined()
+        })
+    })
+
+    describe('edge cases', () => {
+        it('handles behavior with empty metadata array', () => {
+            const behaviors = createBehaviorMap({
+                5: {
+                    id: 5,
+                    displayName: 'Empty Behavior',
+                    metadata: [],
+                },
+            })
+            const binding = createMockBinding(5, 1, 2)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(false)
+            expect(result.type).toBeNull()
+        })
+
+        it('handles case-insensitive behavior name matching', () => {
+            const behaviors = createBehaviorMap({
+                6: createMockBehavior(6, 'LAYER-TAP', true, true),
+            })
+            const binding = createMockBinding(6, 1, 4)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.LayerTap)
+        })
+
+        it('handles display name with "Layer Tap" (space instead of hyphen)', () => {
+            const behaviors = createBehaviorMap({
+                7: createMockBehavior(7, 'Layer Tap', true, true),
+            })
+            const binding = createMockBinding(7, 1, 4)
+
+            const result = isHoldTapBinding(binding, behaviors)
+
+            expect(result.isHoldTap).toBe(true)
+            expect(result.type).toBe(HoldTapType.LayerTap)
+        })
+
+        it('handles binding with zero parameters', () => {
+            const behaviors = createBehaviorMap({
+                1: createMockBehavior(1, 'Layer-Tap', true, true),
+            })
+            const binding = createMockBinding(1, 0, 0)
+
+            const parsed = parseHoldTapBinding(binding, behaviors)
+
+            expect(parsed).not.toBeNull()
+            expect(parsed?.holdParam).toBe(0)
+            expect(parsed?.tapParam).toBe(0)
+        })
+    })
+})

--- a/src/renderer/src/helpers/HoldTapBindings.ts
+++ b/src/renderer/src/helpers/HoldTapBindings.ts
@@ -1,0 +1,290 @@
+/**
+ * Hold-Tap Binding Detection and Parsing Utilities
+ *
+ * This module provides utilities for detecting and parsing hold-tap behavior bindings
+ * (Layer-Tap, Mod-Tap, Sticky Key) used in ZMK keyboards.
+ */
+
+/**
+ * Enum representing the types of hold-tap behaviors supported
+ */
+export enum HoldTapType {
+    /** Layer-Tap: Hold activates a layer, tap sends a keycode */
+    LayerTap = 'layer-tap',
+    /** Mod-Tap: Hold activates a modifier, tap sends a keycode */
+    ModTap = 'mod-tap',
+    /** Sticky Key: Single-press activates a key/modifier that stays active for the next key */
+    StickyKey = 'sticky-key',
+    /** Custom Hold-Tap: A user-defined hold-tap behavior */
+    Custom = 'custom',
+}
+
+/**
+ * Represents a parsed hold-tap binding with extracted tap and hold actions
+ */
+export interface HoldTapBinding {
+    /** The type of hold-tap behavior */
+    type: HoldTapType
+    /** The behavior ID from the original binding */
+    behaviorId: number
+    /** The hold action parameter (layer ID or modifier) */
+    holdParam: number
+    /** The tap action parameter (keycode), undefined for single-param behaviors like sticky key */
+    tapParam: number | undefined
+    /** Whether this binding has both hold and tap parameters */
+    hasTapAndHold: boolean
+}
+
+/**
+ * Result of checking if a behavior is a hold-tap type
+ */
+export interface HoldTapDetectionResult {
+    /** Whether the binding is a hold-tap type */
+    isHoldTap: boolean
+    /** The detected hold-tap type, if applicable */
+    type: HoldTapType | null
+}
+
+/**
+ * Minimal interface for BehaviorBinding (matches ZMK library structure)
+ */
+export interface BehaviorBindingLike {
+    behaviorId: number
+    param1: number
+    param2: number
+}
+
+/**
+ * Minimal interface for behavior parameter value description
+ */
+export interface BehaviorParameterValueDescriptionLike {
+    name?: string
+    nil?: object
+    constant?: number
+    range?: { min: number; max: number }
+    hidUsage?: { keyboardMax: number; consumerMax: number }
+    layerId?: object
+}
+
+/**
+ * Minimal interface for behavior binding parameter set
+ */
+export interface BehaviorBindingParametersSetLike {
+    param1: BehaviorParameterValueDescriptionLike[]
+    param2: BehaviorParameterValueDescriptionLike[]
+}
+
+/**
+ * Minimal interface for behavior details response
+ */
+export interface BehaviorDetailsLike {
+    id: number
+    displayName: string
+    metadata: BehaviorBindingParametersSetLike[]
+}
+
+/**
+ * Map of behavior IDs to behavior details
+ */
+export type BehaviorMapLike = Record<number, BehaviorDetailsLike>
+
+/**
+ * Determines the hold-tap type based on behavior display name
+ */
+function getHoldTapTypeFromName(displayName: string): HoldTapType | null {
+    const lowerName = displayName.toLowerCase()
+
+    if (
+        lowerName.includes('layer-tap') ||
+        lowerName.includes('layer tap') ||
+        lowerName === 'lt'
+    ) {
+        return HoldTapType.LayerTap
+    }
+
+    if (
+        lowerName.includes('mod-tap') ||
+        lowerName.includes('mod tap') ||
+        lowerName === 'mt'
+    ) {
+        return HoldTapType.ModTap
+    }
+
+    if (
+        lowerName.includes('sticky') ||
+        lowerName.includes('sticky-key') ||
+        lowerName === 'sk'
+    ) {
+        return HoldTapType.StickyKey
+    }
+
+    return null
+}
+
+/**
+ * Analyzes behavior metadata to determine if it's a hold-tap type based on parameter structure
+ */
+function analyzeMetadataForHoldTap(
+    metadata: BehaviorBindingParametersSetLike[],
+): { isHoldTap: boolean; hasLayerParam: boolean; hasTwoParams: boolean } {
+    if (!metadata || metadata.length === 0) {
+        return { isHoldTap: false, hasLayerParam: false, hasTwoParams: false }
+    }
+
+    // Check the first parameter set (most common case)
+    const firstSet = metadata[0]
+    const hasParam1 = firstSet.param1 && firstSet.param1.length > 0
+    const hasParam2 = firstSet.param2 && firstSet.param2.length > 0
+
+    // Check if param1 contains a layer ID parameter
+    const hasLayerParam =
+        hasParam1 &&
+        firstSet.param1.some(
+            (p) => p.layerId !== undefined && p.layerId !== null,
+        )
+
+    // A hold-tap typically has at least one parameter
+    // Two-param behaviors (layer-tap, mod-tap) have both param1 and param2
+    // Single-param behaviors (sticky-key) have only param1
+    const isHoldTap = hasParam1
+    const hasTwoParams = hasParam1 && hasParam2
+
+    return { isHoldTap, hasLayerParam, hasTwoParams }
+}
+
+/**
+ * Detects if a binding represents a hold-tap behavior
+ *
+ * @param binding - The behavior binding to check
+ * @param behaviors - Map of all available behaviors
+ * @returns Detection result indicating if binding is hold-tap and its type
+ *
+ * @example
+ * ```typescript
+ * const result = isHoldTapBinding(binding, behaviorMap);
+ * if (result.isHoldTap) {
+ *   console.log(`This is a ${result.type} binding`);
+ * }
+ * ```
+ */
+export function isHoldTapBinding(
+    binding: BehaviorBindingLike,
+    behaviors: BehaviorMapLike,
+): HoldTapDetectionResult {
+    const behavior = behaviors[binding.behaviorId]
+
+    if (!behavior) {
+        return { isHoldTap: false, type: null }
+    }
+
+    // First, try to detect from behavior name
+    const typeFromName = getHoldTapTypeFromName(behavior.displayName)
+    if (typeFromName !== null) {
+        return { isHoldTap: true, type: typeFromName }
+    }
+
+    // Fallback: Analyze metadata structure
+    const { isHoldTap, hasLayerParam, hasTwoParams } = analyzeMetadataForHoldTap(
+        behavior.metadata,
+    )
+
+    if (!isHoldTap) {
+        return { isHoldTap: false, type: null }
+    }
+
+    // Infer type from parameter structure
+    if (hasLayerParam) {
+        return { isHoldTap: true, type: HoldTapType.LayerTap }
+    }
+
+    if (hasTwoParams) {
+        // Has two params but not a layer - likely mod-tap or custom
+        return { isHoldTap: true, type: HoldTapType.Custom }
+    }
+
+    // Single param behavior - could be sticky key
+    return { isHoldTap: true, type: HoldTapType.StickyKey }
+}
+
+/**
+ * Parses a hold-tap binding to extract tap and hold action parameters
+ *
+ * @param binding - The behavior binding to parse
+ * @param behaviors - Map of all available behaviors
+ * @returns Parsed hold-tap binding with extracted parameters, or null if not a hold-tap
+ *
+ * @example
+ * ```typescript
+ * const parsed = parseHoldTapBinding(binding, behaviorMap);
+ * if (parsed) {
+ *   console.log(`Hold: ${parsed.holdParam}, Tap: ${parsed.tapParam}`);
+ * }
+ * ```
+ */
+export function parseHoldTapBinding(
+    binding: BehaviorBindingLike,
+    behaviors: BehaviorMapLike,
+): HoldTapBinding | null {
+    const detection = isHoldTapBinding(binding, behaviors)
+
+    if (!detection.isHoldTap || detection.type === null) {
+        return null
+    }
+
+    const behavior = behaviors[binding.behaviorId]
+    const { hasTwoParams } = analyzeMetadataForHoldTap(behavior.metadata)
+
+    return {
+        type: detection.type,
+        behaviorId: binding.behaviorId,
+        holdParam: binding.param1,
+        tapParam: hasTwoParams ? binding.param2 : undefined,
+        hasTapAndHold: hasTwoParams,
+    }
+}
+
+/**
+ * Extracts the tap action parameter from a hold-tap binding
+ *
+ * @param binding - The behavior binding to extract from
+ * @param behaviors - Map of all available behaviors
+ * @returns The tap parameter value, or undefined if not a hold-tap or no tap parameter
+ *
+ * @example
+ * ```typescript
+ * const tapKey = getTapParam(binding, behaviorMap);
+ * if (tapKey !== undefined) {
+ *   console.log(`Tap sends keycode: ${tapKey}`);
+ * }
+ * ```
+ */
+export function getTapParam(
+    binding: BehaviorBindingLike,
+    behaviors: BehaviorMapLike,
+): number | undefined {
+    const parsed = parseHoldTapBinding(binding, behaviors)
+    return parsed?.tapParam
+}
+
+/**
+ * Extracts the hold action parameter from a hold-tap binding
+ *
+ * @param binding - The behavior binding to extract from
+ * @param behaviors - Map of all available behaviors
+ * @returns The hold parameter value, or undefined if not a hold-tap
+ *
+ * @example
+ * ```typescript
+ * const holdAction = getHoldParam(binding, behaviorMap);
+ * if (holdAction !== undefined) {
+ *   console.log(`Hold activates: ${holdAction}`);
+ * }
+ * ```
+ */
+export function getHoldParam(
+    binding: BehaviorBindingLike,
+    behaviors: BehaviorMapLike,
+): number | undefined {
+    const parsed = parseHoldTapBinding(binding, behaviors)
+    return parsed?.holdParam
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+        deps: {
+            // Handle ESM/CJS interop issues
+            interopDefault: true,
+        },
+    },
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './src/renderer/src'),
+            'protobufjs/minimal': 'protobufjs/minimal.js',
+        },
+    },
+})


### PR DESCRIPTION
## Summary
## Summary
Create utility functions to identify and parse hold-tap behavior bindings (Layer-Tap, Mod-Tap, Sticky Key) and extract their tap/hold parameters.

## Acceptance Criteria
- [ ] Create helper function to detect if a binding is a hold-tap type (`&lt`, `&mt`, `&sk`, custom hold-tap)
- [ ] Create parser to extract tap action parameter from binding
- [ ] Create parser to extract hold action parameter from binding
- [ ] Add TypeScript types for hold-tap binding structure
- [ ] Unit tests for parsing various hold-tap binding formats

## Files to Modify
- `src/renderer/src/helpers/Behaviors.ts` - Add detection and parsing utilities

Parent issue: #29 Show Layer-Tap/Mod-Tap on keys
https://github.com/Wolffyx/remappr/issues/29

## Plan
# Implementation Plan (Lite)

## Task
Detect and parse hold-tap bindings

## Description
## Summary
Create utility functions to identify and parse hold-tap behavior bindings (Layer-Tap, Mod-Tap, Sticky Key) and extract their tap/hold parameters.

## Acceptance Criteria
- [ ] Create helper function to detect if a binding is a hold-tap type (`&lt`, `&mt`, `&sk`, custom hold-tap)
- [ ] Create parser to extract tap action parameter from binding
- [ ] Create parser to extract hold action parameter from binding
- [ ] Add TypeScript types for hold-tap binding structure
- [ ] Unit tests for parsing various hold-tap binding formats

## Files to Modify
- `src/renderer/src/helpers/Behaviors.ts` - Add detection and parsing utilities

Parent issue: #29 Show Layer-Tap/Mod-Tap on keys
https://github.com/Wolffyx/remappr/issues/29

## Approach
1. Analyze the requirements
2. Identify files to modify
3. Implement changes
4. Run verification commands
5. Commit and push

## Commands to Run
- pnpm install
- pnpm lint
- pnpm test
- pnpm build

## Testing
All checks passed

---
Closes #30