### PR TITLE
fix(ci): pass release PR JSON via env to avoid shell quote breakage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
               if: ${{ steps.rp.outputs.pr }}
               env:
                   GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+                  RP_PR: ${{ steps.rp.outputs.pr }}
               run: |
-                  PR_NUM=$(echo '${{ steps.rp.outputs.pr }}' | jq -r '.number')
+                  PR_NUM=$(jq -r '.number' <<< "$RP_PR")
                   echo "Enabling auto-merge on release PR #$PR_NUM"
                   gh pr merge "$PR_NUM" --squash --auto --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
PR body apostrophes broke single-quoted echo, causing syntax error on the compare URL parens. Route through env var + jq heredoc-string.