### PR TITLE
fix(build): Windows usocket patch + pnpm electron-binary install

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -37,14 +37,11 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install -y libudev-dev libusb-1.0-0-dev rpm
 
-            # Windows skips optional deps: dbus-next (Linux-only) pulls the
-            # unix-only native module usocket, which cannot compile on MSVC.
-            - name: Install dependencies (Windows — no unix-only optionals)
-              if: matrix.os == 'windows-latest'
-              run: pnpm install --frozen-lockfile --no-optional
-
+            # usocket (Linux-only native, pulled by dbus-next) is patched to
+            # declare os:[linux,darwin], so pnpm skips it on Windows as a
+            # platform-mismatched optional dep — no need to drop ALL optionals
+            # (which would also skip rollup/swc/lightningcss platform binaries).
             - name: Install dependencies
-              if: matrix.os != 'windows-latest'
               run: pnpm install --frozen-lockfile
 
             - name: Build (Linux)

--- a/package.json
+++ b/package.json
@@ -146,7 +146,18 @@
         },
         "patchedDependencies": {
             "usocket@0.3.0": "patches/usocket@0.3.0.patch"
-        }
+        },
+        "onlyBuiltDependencies": [
+            "electron",
+            "electron-winstaller",
+            "esbuild",
+            "@swc/core",
+            "@serialport/bindings-cpp",
+            "node-hid",
+            "usocket",
+            "protobufjs",
+            "@zmkfirmware/zmk-studio-ts-client"
+        ]
     },
     "lint-staged": {
         "*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -143,6 +143,9 @@
             "tough-cookie": "^4.1.4",
             "qs": "^6.14.1",
             "node-addon-api": "^8.8.0"
+        },
+        "patchedDependencies": {
+            "usocket@0.3.0": "patches/usocket@0.3.0.patch"
         }
     },
     "lint-staged": {

--- a/patches/usocket@0.3.0.patch
+++ b/patches/usocket@0.3.0.patch
@@ -1,0 +1,15 @@
+diff --git a/package.json b/package.json
+index 1b74a9df4adc3ac390cda793aa1f14288547c1f2..9e0155d8a7173e8d893785d057abce320725219e 100644
+--- a/package.json
++++ b/package.json
+@@ -33,5 +33,9 @@
+     "bindings": "^1.5.0",
+     "nan": "^2.14.2",
+     "node-gyp": "^7.1.2"
+-  }
++  },
++  "os": [
++    "linux",
++    "darwin"
++  ]
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,11 @@ overrides:
   qs: ^6.14.1
   node-addon-api: ^8.8.0
 
+patchedDependencies:
+  usocket@0.3.0:
+    hash: 4895109048d14f2d3f7e4b29a7266faa641df5805c11ddc1fc48c27ff412887f
+    path: patches/usocket@0.3.0.patch
+
 importers:
 
   .:
@@ -8543,7 +8548,7 @@ snapshots:
       safe-buffer: 5.2.1
       xml2js: 0.6.2
     optionalDependencies:
-      usocket: 0.3.0
+      usocket: 0.3.0(patch_hash=4895109048d14f2d3f7e4b29a7266faa641df5805c11ddc1fc48c27ff412887f)
     optional: true
 
   debug@4.4.0:
@@ -11301,7 +11306,7 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  usocket@0.3.0:
+  usocket@0.3.0(patch_hash=4895109048d14f2d3f7e4b29a7266faa641df5805c11ddc1fc48c27ff412887f):
     dependencies:
       bindings: 1.5.0
       nan: 2.26.2


### PR DESCRIPTION
Two pnpm install-layer fixes.

### 1. Windows build — usocket
#135 used `pnpm install --no-optional`, which skips EVERY optional dep, including rollup's required `@rollup/rollup-win32-x64-msvc` (and swc/lightningcss natives) → Vite build dies with `Cannot find module @rollup/rollup-win32-x64-msvc`. Instead, patch `usocket` (unix-only native pulled by dbus-next) to declare `os:[linux,darwin]` so pnpm skips just it on Windows; CI back to a single `pnpm install --frozen-lockfile`.

### 2. Dev app — Electron binary not installed
pnpm 10 blocks dependencies' postinstall scripts by default, so Electron's installer never ran → `electron-vite dev` failed with `Error: Electron uninstall` (getElectronPath can't find the binary). That's the pnpm-vs-npm difference the user hit. Add `pnpm.onlyBuiltDependencies` allowlisting electron + the native/build deps so a plain `pnpm install` provisions a runnable dev app.