### PR TITLE
fix(build): strip usocket on Windows + bsdtar for Linux pacman

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,7 +35,7 @@ jobs:
               if: matrix.os == 'ubuntu-latest'
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y libudev-dev libusb-1.0-0-dev rpm
+                  sudo apt-get install -y libudev-dev libusb-1.0-0-dev rpm libarchive-tools
 
             # usocket (Linux-only native, pulled by dbus-next) is patched to
             # declare os:[linux,darwin], so pnpm skips it on Windows as a

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
         "typecheck": "pnpm typecheck:node && pnpm typecheck:web",
         "prepare": "husky",
-        "postinstall": "electron-builder install-app-deps",
+        "postinstall": "node scripts/strip-incompatible-native.cjs && electron-builder install-app-deps",
         "build:unpack": "electron-vite build && electron-builder --dir --config electron-builder.config.cjs",
         "build:win": "electron-vite build && electron-builder --win --publish never --config electron-builder.config.cjs",
         "build:mac": "electron-vite build && electron-builder --mac --publish never --config electron-builder.config.cjs",

--- a/scripts/strip-incompatible-native.cjs
+++ b/scripts/strip-incompatible-native.cjs
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */ // plain CJS — no TS annotations
 // pattern-check: skip — mechanical fs cleanup script, no abstraction/new logic
 //
 // usocket is a Unix-only native addon (uses sys/ioctl.h + unix sockets) pulled
@@ -25,9 +26,13 @@ const pnpmDir = path.join(__dirname, '..', 'node_modules', '.pnpm')
 function rm(target) {
     try {
         fs.rmSync(target, { recursive: true, force: true })
-        console.log(`strip-incompatible-native: removed ${path.relative(process.cwd(), target)}`)
+        console.log(
+            `strip-incompatible-native: removed ${path.relative(process.cwd(), target)}`,
+        )
     } catch (err) {
-        console.warn(`strip-incompatible-native: could not remove ${target}: ${err.message}`)
+        console.warn(
+            `strip-incompatible-native: could not remove ${target}: ${err.message}`,
+        )
     }
 }
 

--- a/scripts/strip-incompatible-native.cjs
+++ b/scripts/strip-incompatible-native.cjs
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// pattern-check: skip — mechanical fs cleanup script, no abstraction/new logic
+//
+// usocket is a Unix-only native addon (uses sys/ioctl.h + unix sockets) pulled
+// in as an OPTIONAL dependency of dbus-next, which is itself Linux-only. The
+// `os: [linux, darwin]` patch on usocket is not honored by pnpm under a frozen
+// lockfile (the lockfile records os from registry metadata, not the patched
+// manifest) nor by @electron/rebuild, so usocket still lands in node_modules on
+// Windows and electron-builder's native rebuild fails compiling it.
+//
+// Since dbus-next is never used on Windows, strip usocket from the install tree
+// on win32 BEFORE any electron rebuild runs (this script is the first half of
+// the root `postinstall`). No-op on Linux/macOS, where usocket builds fine and
+// dbus-next needs it.
+
+const fs = require('fs')
+const path = require('path')
+
+if (process.platform !== 'win32') {
+    process.exit(0)
+}
+
+const pnpmDir = path.join(__dirname, '..', 'node_modules', '.pnpm')
+
+function rm(target) {
+    try {
+        fs.rmSync(target, { recursive: true, force: true })
+        console.log(`strip-incompatible-native: removed ${path.relative(process.cwd(), target)}`)
+    } catch (err) {
+        console.warn(`strip-incompatible-native: could not remove ${target}: ${err.message}`)
+    }
+}
+
+if (!fs.existsSync(pnpmDir)) {
+    process.exit(0)
+}
+
+for (const entry of fs.readdirSync(pnpmDir)) {
+    // The real package store dir, e.g. usocket@0.3.0_patch_hash=...
+    if (entry.startsWith('usocket@')) {
+        rm(path.join(pnpmDir, entry))
+        continue
+    }
+    // The symlink dbus-next@x/node_modules/usocket pointing into the store.
+    const linked = path.join(pnpmDir, entry, 'node_modules', 'usocket')
+    if (fs.existsSync(linked)) {
+        rm(linked)
+    }
+}


### PR DESCRIPTION
Follow-up to #139 — fixes the two remaining platform-specific `build-release` failures ([run 27270401932](https://github.com/Wolffyx/remappr/actions/runs/27270401932); macOS passed).

## Windows — `Install dependencies`

`electron-builder`'s native rebuild (`@electron/rebuild`, invoked by both the root `postinstall` and `build:win` packaging) tries to compile **usocket** → `uwrap.cc: Cannot open include file 'sys/ioctl.h'`. usocket is a Unix-only addon (unix sockets), pulled as an *optional* dep of dbus-next.

Its `os:[linux,darwin]` patch fixes nothing here: pnpm under `--frozen-lockfile` records `os` from registry metadata (the lockfile's usocket entry has no `os`), and `@electron/rebuild` ignores the field entirely — so usocket lands in `node_modules` on Windows and breaks the build.

dbus-next is loaded lazily and **only on Linux** (`src/main/bluez.ts:88` returns early on non-Linux), so usocket is never needed on Windows. New `scripts/strip-incompatible-native.cjs` removes it from the install tree on win32 before any rebuild runs — no-op on Linux/macOS where usocket builds fine and is required.

## Linux — `Build` (pacman target)

`pacman` packaging's fpm step shells out to `bsdtar` → exit 127 (not found). AppImage/deb/rpm/tar.gz already built. Added `libarchive-tools` (provides `bsdtar`) to the Linux deps step.

## Verification

- Linux: full `postinstall` chain exits 0, usocket kept + rebuilt.
- win32 strip dry-run targets exactly the usocket store dir + dbus-next symlink, nothing else.