### PR TITLE
ci: build Pages in remappr env so the builder isn't stubbed on remappr.com

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,14 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    # Single deploy job since we're just deploying
-    deploy:
-        environment:
-            name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
+    # Build runs in the `remappr` environment so the Fetch step can read
+    # REMAPPR_GIT_TOKEN (an environment secret there) and clone the private
+    # builder. The deploy job must use the `github-pages` environment, and a job
+    # can only declare ONE environment — hence build + deploy are split (the
+    # GitHub-recommended Pages pattern). Without this, a single github-pages job
+    # sees no token and the builder falls back to the stub on remappr.com.
+    build:
+        environment: remappr
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -59,6 +62,14 @@ jobs:
               with:
                   # Upload dist folder
                   path: './dist'
+
+    deploy:
+        needs: build
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        steps:
             - name: Deploy to GitHub Pages
               id: deployment
               uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     renderer: {
         define: versionDefine,
         resolve: {
-            // See scripts/remappr-dedupe.mjs — single copy of context/store deps
+            // See scripts/remappr-dedupe.ts — single copy of context/store deps
             // across the app + symlinked @remappr/* sibling repos.
             dedupe: remapprDedupe,
             alias: {


### PR DESCRIPTION
## Problem
The builder is stubbed on production (https://remappr.com). The main.yml Pages deploy log shows:

```
[link-remappr] builder is private and no token (REMAPPR_GIT_TOKEN/GITHUB_TOKEN) is set — skipping fetch.
[link-remappr] builder -> stub (optional, unavailable)
```

The deploy job ran in the `github-pages` environment, but `REMAPPR_GIT_TOKEN` is a secret scoped to the **`remappr`** environment → invisible in that job → empty → the private `remapprBuilder` clone is skipped → stub ships.

## Fix
Split the single job into:
- **build** (`environment: remappr`) — token available, fetches @remappr projects, builds, uploads the Pages artifact
- **deploy** (`environment: github-pages`) — deploys the artifact

A job can only declare one environment; this is GitHub's standard Pages build/deploy split. Also fixes a stale comment (`remappr-dedupe.mjs` → `.ts`).

## ⚠️ Still required: a valid token
This makes the token *reachable*. It must also be *valid*: the PR-preview run (which already uses `environment: remappr`) failed with `remote: Invalid username or token`. Set `REMAPPR_GIT_TOKEN` in the **`remappr`** environment to a valid token with read access to `remapprBuilder`:
- classic PAT with the `repo` scope, **or**
- fine-grained PAT with `Contents: Read` on `Wolffyx/remapprBuilder`.

Both this merge **and** a valid token are needed before the builder renders on remappr.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)