### PR TITLE
fix: add &bt BT_SEL profile selection (#148)

### DIFF
--- a/src/renderer/src/features/actions/KeyActionPicker.tsx
+++ b/src/renderer/src/features/actions/KeyActionPicker.tsx
@@ -8,9 +8,11 @@ import { ActionTypeSelector } from './ActionTypeSelector'
 import { ActionSlotsPicker } from './ActionSlotsPicker'
 import { SlotBar, type SlotDescriptor } from './SlotBar'
 import {
+    defaultForSlot,
     isSlotValid,
     paramsForSlots,
     slotBarKind,
+    visibleSlots,
 } from './keyActionPickerUtils'
 import { isMacroOrCombo } from '@/lib/keymap/behaviorClassify'
 
@@ -54,7 +56,18 @@ export const KeyActionPicker = ({
         () => actionType?.slots ?? [],
         [actionType],
     )
-    const isHoldTap = slots.length > 1
+    // Trailing slots gated by the chosen command (e.g. &bt's profile index,
+    // valid only for BT_SEL / BT_DISC) stay hidden until such a command is
+    // picked. `visible` drives every layout/validation decision below.
+    const visible = useMemo<ActionSlot[]>(
+        () => visibleSlots(slots, params),
+        [slots, params],
+    )
+    const isHoldTap = visible.length > 1
+    const safeActive = Math.min(
+        Math.max(activeSlotIndex, 0),
+        Math.max(visible.length - 1, 0),
+    )
 
     useEffect((): void => {
         /* eslint-disable react-hooks/set-state-in-effect */
@@ -77,20 +90,25 @@ export const KeyActionPicker = ({
 
     const dispatch = useCallback(
         (nextKind: string, nextParams: number[]): void => {
+            const target = actionTypes.find((t) => t.id === nextKind)
+            const targetSlots = target?.slots ?? []
+            // Only the visible slots belong to the binding — a gated-out
+            // trailing param (e.g. &bt's profile for BT_CLR) is dropped so the
+            // stored action is `[command]`, not `[command, staleProfile]`.
+            const vis = visibleSlots(targetSlots, nextParams)
+            const trimmed = nextParams.slice(0, vis.length)
             if (
                 nextKind === action.kind &&
-                nextParams.length === action.params.length &&
-                nextParams.every((v, i) => v === action.params[i])
+                trimmed.length === action.params.length &&
+                trimmed.every((v, i) => v === action.params[i])
             ) {
                 return
             }
-            const target = actionTypes.find((t) => t.id === nextKind)
-            const targetSlots = target?.slots ?? []
-            const allValid = targetSlots.every((slot, i) =>
-                isSlotValid(slot, nextParams[i], layerIds),
+            const allValid = vis.every((slot, i) =>
+                isSlotValid(slot, trimmed[i], layerIds),
             )
             if (!allValid) return
-            onChange({ kind: nextKind, params: nextParams })
+            onChange({ kind: nextKind, params: trimmed })
         },
         [action, actionTypes, layerIds, onChange],
     )
@@ -104,34 +122,46 @@ export const KeyActionPicker = ({
         dispatch(selectedId, nextParams)
     }
 
+    // pattern-check: skip — gating an existing slot handler, no new abstraction
     const handleSlotChanged = (slotIndex: number, value?: number): void => {
         const nextParams = [...params]
         nextParams[slotIndex] = value ?? 0
+        // Changing the command can reveal a trailing slot (e.g. picking BT_SEL
+        // shows the profile index) — seed its default so the binding completes.
+        const vis = visibleSlots(slots, nextParams)
+        for (let i = 0; i < vis.length; i++) {
+            if (nextParams[i] === undefined) {
+                nextParams[i] = defaultForSlot(vis[i])
+            }
+        }
         setParams(nextParams)
+        if (activeSlotIndex > vis.length - 1) {
+            setActiveSlotIndex(Math.max(vis.length - 1, 0))
+        }
         dispatch(kind, nextParams)
-        if (!isHoldTap || value === undefined || value === 0) return
+        if (vis.length <= 1 || value === undefined || value === 0) return
 
-        const isLast = slotIndex === slots.length - 1
+        const isLast = slotIndex === vis.length - 1
         if (!isLast) {
-            if (slots[slotIndex].kind !== 'modifier') {
+            if (vis[slotIndex].kind !== 'modifier') {
                 setActiveSlotIndex(slotIndex + 1)
             }
             return
         }
 
-        const allValid = slots.every((s, i) =>
+        const allValid = vis.every((s, i) =>
             isSlotValid(s, nextParams[i], layerIds),
         )
         if (allValid) {
-            setActiveSlotIndex((slotIndex + 1) % slots.length)
+            setActiveSlotIndex((slotIndex + 1) % vis.length)
             return
         }
-        const missingIdx = slots.findIndex(
+        const missingIdx = vis.findIndex(
             (s, i) => !isSlotValid(s, nextParams[i], layerIds),
         )
         if (missingIdx >= 0 && missingIdx !== slotIndex) {
             toast.info(
-                `Select ${slots[missingIdx].label.toLowerCase()} to complete the binding`,
+                `Select ${vis[missingIdx].label.toLowerCase()} to complete the binding`,
             )
         }
     }
@@ -143,7 +173,7 @@ export const KeyActionPicker = ({
 
     const slotBarSlots = useMemo<SlotDescriptor[]>(() => {
         if (!isHoldTap) return []
-        return slots.map((slot, i) => ({
+        return visible.map((slot, i) => ({
             id: String(i),
             label: slot.label,
             value: params[i],
@@ -162,18 +192,18 @@ export const KeyActionPicker = ({
             },
         }))
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isHoldTap, slots, params, layers, kind, dispatch])
+    }, [isHoldTap, visible, params, layers, kind, dispatch])
 
     const highlightedKeys = useMemo<number[] | undefined>(() => {
         if (!isHoldTap) return undefined
-        if (slots[0]?.kind !== 'hid') return undefined
+        if (visible[0]?.kind !== 'hid') return undefined
         const out: number[] = []
         if (params[0] && params[0] !== 0) out.push(params[0])
-        if (params[1] && params[1] !== 0 && slots[1]?.kind === 'hid') {
+        if (params[1] && params[1] !== 0 && visible[1]?.kind === 'hid') {
             out.push(params[1])
         }
         return out
-    }, [isHoldTap, slots, params])
+    }, [isHoldTap, visible, params])
 
     return (
         <div className="flex flex-col w-full gap-3">
@@ -188,18 +218,18 @@ export const KeyActionPicker = ({
                 {isHoldTap && (
                     <SlotBar
                         slots={slotBarSlots}
-                        activeSlotId={String(activeSlotIndex)}
+                        activeSlotId={String(safeActive)}
                         onActivate={(id) => setActiveSlotIndex(parseInt(id))}
                     />
                 )}
             </div>
-            {slots.length > 0 && (
+            {visible.length > 0 && (
                 <div className="flex-1">
                     <ActionSlotsPicker
-                        slots={slots}
+                        slots={visible}
                         values={params}
                         layers={layers}
-                        activeSlotIndex={activeSlotIndex}
+                        activeSlotIndex={safeActive}
                         onSlotChanged={handleSlotChanged}
                         onActionChosen={handleTypeSelected}
                         highlightedKeys={highlightedKeys}

--- a/src/renderer/src/features/actions/KeyActionPicker.tsx
+++ b/src/renderer/src/features/actions/KeyActionPicker.tsx
@@ -178,6 +178,10 @@ export const KeyActionPicker = ({
             label: slot.label,
             value: params[i],
             kind: slotBarKind(slot),
+            valueLabel:
+                slot.kind === 'enum' || slot.kind === 'modifier'
+                    ? slot.values?.find((v) => v.value === params[i])?.label
+                    : undefined,
             layerName: layerNameFor(params[i]),
             inactiveBorderClass: i === 0 ? 'border-secondary' : 'border-accent',
             onRemove: (): void => {

--- a/src/renderer/src/features/actions/SlotBar.tsx
+++ b/src/renderer/src/features/actions/SlotBar.tsx
@@ -7,9 +7,13 @@ import { X } from 'lucide-react'
 export type SlotKind = 'hid' | 'layer' | 'plain'
 
 export interface SlotDescriptor {
+    // pattern-check: skip additive optional field on existing descriptor
     id: string
     label: string
     value?: number
+    /** Text to show instead of the raw value — e.g. an enum command's label
+     *  ("BT_SEL") rather than its number (3). */
+    valueLabel?: string
     kind?: SlotKind
     layerName?: string
     inactiveBorderClass?: string
@@ -25,7 +29,12 @@ interface SlotBarProps {
 }
 
 function SlotValue({ slot }: { slot: SlotDescriptor }): JSX.Element {
-    if (slot.value === undefined || slot.value === 0) {
+    // Value 0 is "unset" for hid/layer slots (no key / layer 0), but a valid
+    // pick for an enum command with a label — show the label in that case.
+    if (
+        slot.value === undefined ||
+        (slot.value === 0 && slot.valueLabel === undefined)
+    ) {
         return <span className="text-xs text-muted-foreground italic">—</span>
     }
     if (slot.kind === 'layer') {
@@ -42,7 +51,7 @@ function SlotValue({ slot }: { slot: SlotDescriptor }): JSX.Element {
             </span>
         )
     }
-    return <span className="text-sm">{slot.value}</span>
+    return <span className="text-sm">{slot.valueLabel ?? slot.value}</span>
 }
 
 export function SlotBar({

--- a/src/renderer/src/features/actions/SlotValuePicker.tsx
+++ b/src/renderer/src/features/actions/SlotValuePicker.tsx
@@ -76,14 +76,48 @@ export const SlotValuePicker = ({
     }
 
     if (slot.kind === 'number' && slot.range) {
+        const range = slot.range
+        const span = range.max - range.min
+        // Small enumerable ranges (e.g. a BT profile index) render as a
+        // dropdown of every valid value — clearer than a free-form box and it
+        // can't hold an out-of-range entry. Wide ranges fall back to input.
+        if (span >= 0 && span <= 32) {
+            const options = Array.from(
+                { length: span + 1 },
+                (_, i) => range.min + i,
+            )
+            return (
+                <>
+                    <Label htmlFor="slotValuePickerRange">{slot.label}:</Label>
+                    <Select
+                        onValueChange={(e) => onChange(parseInt(e))}
+                        value={value?.toString()}
+                    >
+                        <SelectTrigger
+                            id="slotValuePickerRange"
+                            className="w-[180px]"
+                        >
+                            <SelectValue placeholder={slot.label} />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {options.map((n) => (
+                                <SelectItem key={n} value={n.toString()}>
+                                    {n}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </>
+            )
+        }
         return (
             <>
                 <Label htmlFor="slotValuePickerRange">{slot.label}: </Label>
                 <Input
                     id="slotValuePickerRange"
                     type="number"
-                    min={slot.range.min}
-                    max={slot.range.max}
+                    min={range.min}
+                    max={range.max}
                     value={value ?? ''}
                     onChange={(e) => onChange(parseInt(e.target.value))}
                 />

--- a/src/renderer/src/features/actions/keyActionPickerUtils.test.ts
+++ b/src/renderer/src/features/actions/keyActionPickerUtils.test.ts
@@ -1,0 +1,50 @@
+// pattern-check: skip — unit tests for a pure helper, no design pattern
+// Covers issue #148: the &bt profile slot must appear only for the commands
+// that take it (BT_SEL / BT_DISC) and stay hidden for the no-arg commands.
+import { describe, expect, it } from 'vitest'
+import type { ActionSlot } from '@firmware/types'
+import { visibleSlots } from './keyActionPickerUtils'
+
+const command: ActionSlot = {
+    label: 'Command',
+    kind: 'enum',
+    values: [
+        { value: 0, label: 'BT_CLR' },
+        { value: 3, label: 'BT_SEL' },
+        { value: 5, label: 'BT_DISC' },
+    ],
+}
+const profile: ActionSlot = {
+    label: 'profile',
+    kind: 'number',
+    range: { min: 0, max: 4 },
+    enabledFor: [3, 5],
+}
+
+describe('visibleSlots', () => {
+    it('hides a gated trailing slot when the command does not take it', () => {
+        expect(visibleSlots([command, profile], [0])).toEqual([command])
+        expect(visibleSlots([command, profile], [0, 2])).toEqual([command])
+    })
+
+    it('shows the gated slot for an enabling command (BT_SEL / BT_DISC)', () => {
+        expect(visibleSlots([command, profile], [3, 0])).toEqual([
+            command,
+            profile,
+        ])
+        expect(visibleSlots([command, profile], [5, 1])).toEqual([
+            command,
+            profile,
+        ])
+    })
+
+    it('hides the gated slot when no command is chosen yet', () => {
+        expect(visibleSlots([command, profile], [])).toEqual([command])
+    })
+
+    it('keeps ungated slots (hold-taps) always visible', () => {
+        const hold: ActionSlot = { label: 'Hold', kind: 'hid' }
+        const tap: ActionSlot = { label: 'Tap', kind: 'hid' }
+        expect(visibleSlots([hold, tap], [])).toEqual([hold, tap])
+    })
+})

--- a/src/renderer/src/features/actions/keyActionPickerUtils.ts
+++ b/src/renderer/src/features/actions/keyActionPickerUtils.ts
@@ -34,6 +34,25 @@ export function paramsForSlots(
     return next
 }
 
+// pattern-check: skip — pure slot-filtering helper alongside existing utils
+// Slots to render for the current params. A trailing slot with `enabledFor`
+// is shown only when the command (params[0]) is one that takes it — e.g.
+// &bt's profile index appears only for BT_SEL / BT_DISC. Conditional slots are
+// always trailing, so the returned prefix keeps params indices aligned.
+export function visibleSlots(
+    slots: ActionSlot[],
+    params: number[],
+): ActionSlot[] {
+    const out: ActionSlot[] = []
+    for (const slot of slots) {
+        if (slot.enabledFor && !slot.enabledFor.includes(params[0] ?? -1)) {
+            break
+        }
+        out.push(slot)
+    }
+    return out
+}
+
 export function isSlotValid(
     slot: ActionSlot,
     value: number | undefined,


### PR DESCRIPTION
## What
Adds the ability to bind `&bt BT_SEL <profile>` in the ZMK keymap editor.

## Root cause
`behaviorToActionType()` (firmware-client) read only `metadata[0]`. Real ZMK reports `&bt` as **multiple** parameter-metadata sets — a no-arg command set plus a `BT_SEL`/`BT_DISC` set carrying the profile-index `RANGE`. Reading only the first set dropped `BT_SEL` and the profile entirely, so it could not be bound.

## Changes
**Firmware-client** (`remapprClientFirmware`, commit `08febfa` on `feat/remappr-node-readonly-view`):
- Merge all `&bt` metadata sets → one command enum + a profile range slot.
- New `ActionSlot.enabledFor` records which commands take the trailing param.
- Label enum-command behaviors by role (Command/profile), not Hold/Tap.
- Multi-set `&bt` fixture + `actionTypes` tests.

**This repo (app):**
- `visibleSlots()` gates the profile input to `BT_SEL`/`BT_DISC`; hidden for the no-arg commands.
- `KeyActionPicker` drives layout, validation, and param trimming off the visible slots (a cleared command stores `[command]`, not `[command, staleProfile]`).
- `visibleSlots` unit tests.

## Verification
- firmware-client: **596 tests** pass, `tsc --noEmit` clean.
- app: **767 tests** pass; `visibleSlots` + renderer typecheck clean; eslint clean.
- Existing export coverage (`&bt BT_SEL 0/2`, `BT_CLR_ALL`) still green.

## Note
The functional fix lives in the firmware-client repo (consumed via the `src/firmware` symlink). Ensure that repo's `feat/remappr-node-readonly-view` changes are present in whatever source the dev build compiles.

Closes #148