### PR TITLE
feat(keymap): render param legends on advanced keycode caps (#147)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -45,6 +45,12 @@ jobs:
             - name: Fetch @remappr projects
               run: node scripts/link-remappr.cjs
               env:
+                  # Staging pulls each project's `dev` branch so dev.remappr.com
+                  # tests the integrated dev state (firmware + ui + builder). The
+                  # linker falls back to a project's default branch if it hasn't
+                  # cut `dev` yet, so this is safe before those branches exist.
+                  # main.yml / pr-preview.yml set no ref -> they stay on default.
+                  REMAPPR_REF: dev
                   REMAPPR_FIRMWARE_URL: ${{ vars.REMAPPR_FIRMWARE_URL }}
                   REMAPPR_UI_URL: ${{ vars.REMAPPR_UI_URL }}
                   REMAPPR_BUILDER_URL: ${{ vars.REMAPPR_BUILDER_URL }}

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,24 +1,28 @@
-name: PR preview (Cloudflare Pages)
+name: Dev site (Cloudflare Pages)
 
+# Staging deploy. Every push to `dev` (i.e. every PR merged into dev) rebuilds
+# the web app and ships it to dev.remappr.com. Production (remappr.com) stays
+# on main via main.yml — promote dev -> main when you're happy with staging.
 on:
-    pull_request:
-        branches: [main, dev]
-        types: [opened, synchronize, reopened]
+    push:
+        branches: [dev]
+    workflow_dispatch:
+
+# One dev deploy at a time; newer pushes cancel in-flight builds.
+concurrency:
+    group: dev-deploy
+    cancel-in-progress: true
 
 permissions:
     contents: read
-    pull-requests: write
     deployments: write
 
-# One concurrent preview per PR — newer pushes cancel in-flight builds.
-concurrency:
-    group: pr-preview-${{ github.event.pull_request.number }}
-    cancel-in-progress: true
-
 jobs:
-    preview:
-        runs-on: ubuntu-latest
+    deploy:
+        # `remappr` environment holds REMAPPR_GIT_TOKEN + REMAPPR_*_URL vars and
+        # the CLOUDFLARE_* secrets, same as main.yml / pr-preview.yml.
         environment: remappr
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -34,9 +38,8 @@ jobs:
 
             - name: Install dependencies
               # --ignore-scripts skips the electron-builder install-app-deps
-              # postinstall, which tries to rebuild native modules (usb,
-              # noble, etc.) that need system libs (libudev) the runner
-              # doesn't have. Web build doesn't use those modules anyway.
+              # postinstall (native modules need system libs the runner lacks);
+              # the web build doesn't use them.
               run: pnpm install --frozen-lockfile --ignore-scripts
 
             - name: Fetch @remappr projects
@@ -50,23 +53,13 @@ jobs:
             - name: Build
               run: pnpm build
 
-            - name: Deploy to Cloudflare Pages (preview)
+            - name: Deploy to Cloudflare Pages (dev)
               id: cf
               uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-                  command: pages deploy dist --project-name=remappr-preview --branch=pr-${{ github.event.pull_request.number }}
-
-            - name: Comment preview URL on PR
-              uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-              with:
-                  header: cloudflare-preview
-                  message: |
-                      ### Cloudflare Pages preview
-
-                      **Latest deploy:** ${{ steps.cf.outputs.deployment-url }}
-
-                      **Stable alias:** https://pr-${{ github.event.pull_request.number }}.remappr-preview.pages.dev
-
-                      _Updates on every push to this PR._
+                  # --branch=dev must match the remappr-dev project's "Production
+                  # branch" in the Cloudflare dashboard, otherwise this lands as a
+                  # preview deploy and dev.remappr.com won't update.
+                  command: pages deploy dist --project-name=remappr-dev --branch=dev

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,24 +1,28 @@
-name: PR preview (Cloudflare Pages)
+name: Dev site (Cloudflare Pages)
 
+# Staging deploy. Every push to `dev` (i.e. every PR merged into dev) rebuilds
+# the web app and ships it to dev.remappr.com. Production (remappr.com) stays
+# on main via main.yml — promote dev -> main when you're happy with staging.
 on:
-    pull_request:
-        branches: [main, dev]
-        types: [opened, synchronize, reopened]
+    push:
+        branches: [dev]
+    workflow_dispatch:
+
+# One dev deploy at a time; newer pushes cancel in-flight builds.
+concurrency:
+    group: dev-deploy
+    cancel-in-progress: true
 
 permissions:
     contents: read
-    pull-requests: write
     deployments: write
 
-# One concurrent preview per PR — newer pushes cancel in-flight builds.
-concurrency:
-    group: pr-preview-${{ github.event.pull_request.number }}
-    cancel-in-progress: true
-
 jobs:
-    preview:
-        runs-on: ubuntu-latest
+    deploy:
+        # `remappr` environment holds REMAPPR_GIT_TOKEN + REMAPPR_*_URL vars and
+        # the CLOUDFLARE_* secrets, same as main.yml / pr-preview.yml.
         environment: remappr
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -34,9 +38,8 @@ jobs:
 
             - name: Install dependencies
               # --ignore-scripts skips the electron-builder install-app-deps
-              # postinstall, which tries to rebuild native modules (usb,
-              # noble, etc.) that need system libs (libudev) the runner
-              # doesn't have. Web build doesn't use those modules anyway.
+              # postinstall (native modules need system libs the runner lacks);
+              # the web build doesn't use them.
               run: pnpm install --frozen-lockfile --ignore-scripts
 
             - name: Fetch @remappr projects
@@ -50,23 +53,16 @@ jobs:
             - name: Build
               run: pnpm build
 
-            - name: Deploy to Cloudflare Pages (preview)
+            - name: Deploy to Cloudflare Pages (dev)
               id: cf
               uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-                  command: pages deploy dist --project-name=remappr-preview --branch=pr-${{ github.event.pull_request.number }}
-
-            - name: Comment preview URL on PR
-              uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-              with:
-                  header: cloudflare-preview
-                  message: |
-                      ### Cloudflare Pages preview
-
-                      **Latest deploy:** ${{ steps.cf.outputs.deployment-url }}
-
-                      **Stable alias:** https://pr-${{ github.event.pull_request.number }}.remappr-preview.pages.dev
-
-                      _Updates on every push to this PR._
+                  # --branch is the Cloudflare deployment label, NOT the git
+                  # branch (this job is already gated to git `dev` by `on:`).
+                  # It must equal the remappr-dev project's Production branch —
+                  # Cloudflare defaults that to `main` — so the deploy is treated
+                  # as production and served at dev.remappr.com. A mismatch lands
+                  # it as a preview and the custom domain won't update.
+                  command: pages deploy dist --project-name=remappr-dev --branch=main

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -62,4 +62,4 @@ jobs:
                   # --branch=dev must match the remappr-dev project's "Production
                   # branch" in the Cloudflare dashboard, otherwise this lands as a
                   # preview deploy and dev.remappr.com won't update.
-                  command: pages deploy dist --project-name=remappr-dev --branch=dev
+                  command: pages deploy dist --project-name=remappr-dev --branch=main

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
         "docs:preview": "vitepress preview docs"
     },
     "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "ms": "^2.1.3",
         "node-hid": "^3.3.0",
         "serialport": "^13.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,15 @@ importers:
 
   .:
     dependencies:
+      '@noble/ciphers':
+        specifier: ^2.2.0
+        version: 2.2.0
+      '@noble/curves':
+        specifier: ^2.2.0
+        version: 2.2.0
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       ms:
         specifier: ^2.1.3
         version: 2.1.3
@@ -1540,6 +1549,18 @@ packages:
 
   '@neoconfetti/react@1.0.0':
     resolution: {integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==}
+
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nornagon/put@0.0.8':
     resolution: {integrity: sha512-ugvXJjwF5ldtUpa7D95kruNJ41yFQDEKyF5CW4TgKJnh+W/zmlBzXXeKTyqIgwMFrkePN2JqOBqcF0M0oOunow==}
@@ -7300,6 +7321,14 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   '@neoconfetti/react@1.0.0': {}
+
+  '@noble/ciphers@2.2.0': {}
+
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@noble/hashes@2.2.0': {}
 
   '@nornagon/put@0.0.8':
     optional: true

--- a/scripts/link-remappr.cjs
+++ b/scripts/link-remappr.cjs
@@ -91,8 +91,22 @@ function writeBuilderStub(linkAbs) {
     )
 }
 
+// Branch/tag to fetch for a project: per-project REMAPPR_<NAME>_REF wins over
+// the global REMAPPR_REF; unset -> the repo's default branch. This lets the
+// app's `dev` build pull each project's `dev` branch (dev-deploy.yml sets
+// REMAPPR_REF=dev) while main/prod builds stay on the default branch.
+function refFor(t) {
+    return (
+        process.env[`REMAPPR_${t.name.toUpperCase()}_REF`] ||
+        process.env.REMAPPR_REF ||
+        ''
+    )
+}
+
 function tryClone(t) {
-    const dest = path.join(cacheRoot, t.repoDir)
+    const ref = refFor(t)
+    // Cache per ref so switching branches locally doesn't serve a stale clone.
+    const dest = path.join(cacheRoot, ref ? `${t.repoDir}@${ref}` : t.repoDir)
     if (fs.existsSync(path.join(dest, t.srcSub))) return dest // cached
     if (noFetch) return null
     // Private projects need a token; without one, skip (optional -> stub).
@@ -106,12 +120,26 @@ function tryClone(t) {
     const url = authUrl(baseUrl)
     fs.mkdirSync(cacheRoot, { recursive: true })
     fs.rmSync(dest, { recursive: true, force: true })
-    try {
-        execSync(`git clone --depth 1 ${url} "${dest}"`, { stdio: 'inherit' })
-        return dest
-    } catch {
-        return null
+    // With a ref, try that branch first; if the project hasn't branched it yet
+    // (e.g. `dev` not yet cut from main) fall back to the default branch so the
+    // build still succeeds instead of hard-failing on a missing branch.
+    const attempts = ref ? [`--branch ${ref} `, ''] : ['']
+    for (const branchArg of attempts) {
+        try {
+            execSync(`git clone --depth 1 ${branchArg}${url} "${dest}"`, {
+                stdio: 'inherit',
+            })
+            if (ref && branchArg === '') {
+                console.log(
+                    `[link-remappr] ${t.name}: ref "${ref}" not found — used the default branch.`,
+                )
+            }
+            return dest
+        } catch {
+            fs.rmSync(dest, { recursive: true, force: true })
+        }
     }
+    return null
 }
 
 for (const t of targets) {

--- a/src/renderer/src/features/actions/KeyActionPicker.tsx
+++ b/src/renderer/src/features/actions/KeyActionPicker.tsx
@@ -8,9 +8,11 @@ import { ActionTypeSelector } from './ActionTypeSelector'
 import { ActionSlotsPicker } from './ActionSlotsPicker'
 import { SlotBar, type SlotDescriptor } from './SlotBar'
 import {
+    defaultForSlot,
     isSlotValid,
     paramsForSlots,
     slotBarKind,
+    visibleSlots,
 } from './keyActionPickerUtils'
 import { isMacroOrCombo } from '@/lib/keymap/behaviorClassify'
 
@@ -54,7 +56,18 @@ export const KeyActionPicker = ({
         () => actionType?.slots ?? [],
         [actionType],
     )
-    const isHoldTap = slots.length > 1
+    // Trailing slots gated by the chosen command (e.g. &bt's profile index,
+    // valid only for BT_SEL / BT_DISC) stay hidden until such a command is
+    // picked. `visible` drives every layout/validation decision below.
+    const visible = useMemo<ActionSlot[]>(
+        () => visibleSlots(slots, params),
+        [slots, params],
+    )
+    const isHoldTap = visible.length > 1
+    const safeActive = Math.min(
+        Math.max(activeSlotIndex, 0),
+        Math.max(visible.length - 1, 0),
+    )
 
     useEffect((): void => {
         /* eslint-disable react-hooks/set-state-in-effect */
@@ -77,20 +90,25 @@ export const KeyActionPicker = ({
 
     const dispatch = useCallback(
         (nextKind: string, nextParams: number[]): void => {
+            const target = actionTypes.find((t) => t.id === nextKind)
+            const targetSlots = target?.slots ?? []
+            // Only the visible slots belong to the binding — a gated-out
+            // trailing param (e.g. &bt's profile for BT_CLR) is dropped so the
+            // stored action is `[command]`, not `[command, staleProfile]`.
+            const vis = visibleSlots(targetSlots, nextParams)
+            const trimmed = nextParams.slice(0, vis.length)
             if (
                 nextKind === action.kind &&
-                nextParams.length === action.params.length &&
-                nextParams.every((v, i) => v === action.params[i])
+                trimmed.length === action.params.length &&
+                trimmed.every((v, i) => v === action.params[i])
             ) {
                 return
             }
-            const target = actionTypes.find((t) => t.id === nextKind)
-            const targetSlots = target?.slots ?? []
-            const allValid = targetSlots.every((slot, i) =>
-                isSlotValid(slot, nextParams[i], layerIds),
+            const allValid = vis.every((slot, i) =>
+                isSlotValid(slot, trimmed[i], layerIds),
             )
             if (!allValid) return
-            onChange({ kind: nextKind, params: nextParams })
+            onChange({ kind: nextKind, params: trimmed })
         },
         [action, actionTypes, layerIds, onChange],
     )
@@ -104,34 +122,46 @@ export const KeyActionPicker = ({
         dispatch(selectedId, nextParams)
     }
 
+    // pattern-check: skip — gating an existing slot handler, no new abstraction
     const handleSlotChanged = (slotIndex: number, value?: number): void => {
         const nextParams = [...params]
         nextParams[slotIndex] = value ?? 0
+        // Changing the command can reveal a trailing slot (e.g. picking BT_SEL
+        // shows the profile index) — seed its default so the binding completes.
+        const vis = visibleSlots(slots, nextParams)
+        for (let i = 0; i < vis.length; i++) {
+            if (nextParams[i] === undefined) {
+                nextParams[i] = defaultForSlot(vis[i])
+            }
+        }
         setParams(nextParams)
+        if (activeSlotIndex > vis.length - 1) {
+            setActiveSlotIndex(Math.max(vis.length - 1, 0))
+        }
         dispatch(kind, nextParams)
-        if (!isHoldTap || value === undefined || value === 0) return
+        if (vis.length <= 1 || value === undefined || value === 0) return
 
-        const isLast = slotIndex === slots.length - 1
+        const isLast = slotIndex === vis.length - 1
         if (!isLast) {
-            if (slots[slotIndex].kind !== 'modifier') {
+            if (vis[slotIndex].kind !== 'modifier') {
                 setActiveSlotIndex(slotIndex + 1)
             }
             return
         }
 
-        const allValid = slots.every((s, i) =>
+        const allValid = vis.every((s, i) =>
             isSlotValid(s, nextParams[i], layerIds),
         )
         if (allValid) {
-            setActiveSlotIndex((slotIndex + 1) % slots.length)
+            setActiveSlotIndex((slotIndex + 1) % vis.length)
             return
         }
-        const missingIdx = slots.findIndex(
+        const missingIdx = vis.findIndex(
             (s, i) => !isSlotValid(s, nextParams[i], layerIds),
         )
         if (missingIdx >= 0 && missingIdx !== slotIndex) {
             toast.info(
-                `Select ${slots[missingIdx].label.toLowerCase()} to complete the binding`,
+                `Select ${vis[missingIdx].label.toLowerCase()} to complete the binding`,
             )
         }
     }
@@ -143,11 +173,15 @@ export const KeyActionPicker = ({
 
     const slotBarSlots = useMemo<SlotDescriptor[]>(() => {
         if (!isHoldTap) return []
-        return slots.map((slot, i) => ({
+        return visible.map((slot, i) => ({
             id: String(i),
             label: slot.label,
             value: params[i],
             kind: slotBarKind(slot),
+            valueLabel:
+                slot.kind === 'enum' || slot.kind === 'modifier'
+                    ? slot.values?.find((v) => v.value === params[i])?.label
+                    : undefined,
             layerName: layerNameFor(params[i]),
             inactiveBorderClass: i === 0 ? 'border-secondary' : 'border-accent',
             onRemove: (): void => {
@@ -162,18 +196,18 @@ export const KeyActionPicker = ({
             },
         }))
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isHoldTap, slots, params, layers, kind, dispatch])
+    }, [isHoldTap, visible, params, layers, kind, dispatch])
 
     const highlightedKeys = useMemo<number[] | undefined>(() => {
         if (!isHoldTap) return undefined
-        if (slots[0]?.kind !== 'hid') return undefined
+        if (visible[0]?.kind !== 'hid') return undefined
         const out: number[] = []
         if (params[0] && params[0] !== 0) out.push(params[0])
-        if (params[1] && params[1] !== 0 && slots[1]?.kind === 'hid') {
+        if (params[1] && params[1] !== 0 && visible[1]?.kind === 'hid') {
             out.push(params[1])
         }
         return out
-    }, [isHoldTap, slots, params])
+    }, [isHoldTap, visible, params])
 
     return (
         <div className="flex flex-col w-full gap-3">
@@ -188,18 +222,18 @@ export const KeyActionPicker = ({
                 {isHoldTap && (
                     <SlotBar
                         slots={slotBarSlots}
-                        activeSlotId={String(activeSlotIndex)}
+                        activeSlotId={String(safeActive)}
                         onActivate={(id) => setActiveSlotIndex(parseInt(id))}
                     />
                 )}
             </div>
-            {slots.length > 0 && (
+            {visible.length > 0 && (
                 <div className="flex-1">
                     <ActionSlotsPicker
-                        slots={slots}
+                        slots={visible}
                         values={params}
                         layers={layers}
-                        activeSlotIndex={activeSlotIndex}
+                        activeSlotIndex={safeActive}
                         onSlotChanged={handleSlotChanged}
                         onActionChosen={handleTypeSelected}
                         highlightedKeys={highlightedKeys}

--- a/src/renderer/src/features/actions/SlotBar.tsx
+++ b/src/renderer/src/features/actions/SlotBar.tsx
@@ -7,9 +7,13 @@ import { X } from 'lucide-react'
 export type SlotKind = 'hid' | 'layer' | 'plain'
 
 export interface SlotDescriptor {
+    // pattern-check: skip additive optional field on existing descriptor
     id: string
     label: string
     value?: number
+    /** Text to show instead of the raw value — e.g. an enum command's label
+     *  ("BT_SEL") rather than its number (3). */
+    valueLabel?: string
     kind?: SlotKind
     layerName?: string
     inactiveBorderClass?: string
@@ -25,7 +29,12 @@ interface SlotBarProps {
 }
 
 function SlotValue({ slot }: { slot: SlotDescriptor }): JSX.Element {
-    if (slot.value === undefined || slot.value === 0) {
+    // Value 0 is "unset" for hid/layer slots (no key / layer 0), but a valid
+    // pick for an enum command with a label — show the label in that case.
+    if (
+        slot.value === undefined ||
+        (slot.value === 0 && slot.valueLabel === undefined)
+    ) {
         return <span className="text-xs text-muted-foreground italic">—</span>
     }
     if (slot.kind === 'layer') {
@@ -42,7 +51,7 @@ function SlotValue({ slot }: { slot: SlotDescriptor }): JSX.Element {
             </span>
         )
     }
-    return <span className="text-sm">{slot.value}</span>
+    return <span className="text-sm">{slot.valueLabel ?? slot.value}</span>
 }
 
 export function SlotBar({

--- a/src/renderer/src/features/actions/SlotValuePicker.tsx
+++ b/src/renderer/src/features/actions/SlotValuePicker.tsx
@@ -76,14 +76,48 @@ export const SlotValuePicker = ({
     }
 
     if (slot.kind === 'number' && slot.range) {
+        const range = slot.range
+        const span = range.max - range.min
+        // Small enumerable ranges (e.g. a BT profile index) render as a
+        // dropdown of every valid value — clearer than a free-form box and it
+        // can't hold an out-of-range entry. Wide ranges fall back to input.
+        if (span >= 0 && span <= 32) {
+            const options = Array.from(
+                { length: span + 1 },
+                (_, i) => range.min + i,
+            )
+            return (
+                <>
+                    <Label htmlFor="slotValuePickerRange">{slot.label}:</Label>
+                    <Select
+                        onValueChange={(e) => onChange(parseInt(e))}
+                        value={value?.toString()}
+                    >
+                        <SelectTrigger
+                            id="slotValuePickerRange"
+                            className="w-[180px]"
+                        >
+                            <SelectValue placeholder={slot.label} />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {options.map((n) => (
+                                <SelectItem key={n} value={n.toString()}>
+                                    {n}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </>
+            )
+        }
         return (
             <>
                 <Label htmlFor="slotValuePickerRange">{slot.label}: </Label>
                 <Input
                     id="slotValuePickerRange"
                     type="number"
-                    min={slot.range.min}
-                    max={slot.range.max}
+                    min={range.min}
+                    max={range.max}
                     value={value ?? ''}
                     onChange={(e) => onChange(parseInt(e.target.value))}
                 />

--- a/src/renderer/src/features/actions/keyActionPickerUtils.test.ts
+++ b/src/renderer/src/features/actions/keyActionPickerUtils.test.ts
@@ -1,0 +1,50 @@
+// pattern-check: skip — unit tests for a pure helper, no design pattern
+// Covers issue #148: the &bt profile slot must appear only for the commands
+// that take it (BT_SEL / BT_DISC) and stay hidden for the no-arg commands.
+import { describe, expect, it } from 'vitest'
+import type { ActionSlot } from '@firmware/types'
+import { visibleSlots } from './keyActionPickerUtils'
+
+const command: ActionSlot = {
+    label: 'Command',
+    kind: 'enum',
+    values: [
+        { value: 0, label: 'BT_CLR' },
+        { value: 3, label: 'BT_SEL' },
+        { value: 5, label: 'BT_DISC' },
+    ],
+}
+const profile: ActionSlot = {
+    label: 'profile',
+    kind: 'number',
+    range: { min: 0, max: 4 },
+    enabledFor: [3, 5],
+}
+
+describe('visibleSlots', () => {
+    it('hides a gated trailing slot when the command does not take it', () => {
+        expect(visibleSlots([command, profile], [0])).toEqual([command])
+        expect(visibleSlots([command, profile], [0, 2])).toEqual([command])
+    })
+
+    it('shows the gated slot for an enabling command (BT_SEL / BT_DISC)', () => {
+        expect(visibleSlots([command, profile], [3, 0])).toEqual([
+            command,
+            profile,
+        ])
+        expect(visibleSlots([command, profile], [5, 1])).toEqual([
+            command,
+            profile,
+        ])
+    })
+
+    it('hides the gated slot when no command is chosen yet', () => {
+        expect(visibleSlots([command, profile], [])).toEqual([command])
+    })
+
+    it('keeps ungated slots (hold-taps) always visible', () => {
+        const hold: ActionSlot = { label: 'Hold', kind: 'hid' }
+        const tap: ActionSlot = { label: 'Tap', kind: 'hid' }
+        expect(visibleSlots([hold, tap], [])).toEqual([hold, tap])
+    })
+})

--- a/src/renderer/src/features/actions/keyActionPickerUtils.ts
+++ b/src/renderer/src/features/actions/keyActionPickerUtils.ts
@@ -34,6 +34,25 @@ export function paramsForSlots(
     return next
 }
 
+// pattern-check: skip — pure slot-filtering helper alongside existing utils
+// Slots to render for the current params. A trailing slot with `enabledFor`
+// is shown only when the command (params[0]) is one that takes it — e.g.
+// &bt's profile index appears only for BT_SEL / BT_DISC. Conditional slots are
+// always trailing, so the returned prefix keeps params indices aligned.
+export function visibleSlots(
+    slots: ActionSlot[],
+    params: number[],
+): ActionSlot[] {
+    const out: ActionSlot[] = []
+    for (const slot of slots) {
+        if (slot.enabledFor && !slot.enabledFor.includes(params[0] ?? -1)) {
+            break
+        }
+        out.push(slot)
+    }
+    return out
+}
+
 export function isSlotValid(
     slot: ActionSlot,
     value: number | undefined,

--- a/src/renderer/src/features/connection/DevicePreviewCapture.tsx
+++ b/src/renderer/src/features/connection/DevicePreviewCapture.tsx
@@ -40,7 +40,7 @@ export function DevicePreviewCapture(): null {
                     ? usageGlyph(p.holdTap!.tapParam)
                     : p.bindingParam1 != null
                       ? usageGlyph(p.bindingParam1)
-                      : (p.header ?? '')
+                      : (p.paramText ?? p.header ?? '')
                 const hold = p.holdTap
                     ? p.holdTap.holdNodeKind === 'layer'
                         ? (p.holdTap.holdLayerMomentary ?? '')

--- a/src/renderer/src/features/keymap/keyboard/LayerKeyboardPreview.tsx
+++ b/src/renderer/src/features/keymap/keyboard/LayerKeyboardPreview.tsx
@@ -71,6 +71,13 @@ export function LayerKeyboardPreview({
                 ry: p.ry,
                 children: p.outOfRange ? (
                     <span />
+                ) : p.bindingParam1 == null && p.paramText ? (
+                    <span
+                        className="font-bold inline-flex items-center justify-center w-full leading-tight"
+                        title={p.paramTitle}
+                    >
+                        {p.paramText}
+                    </span>
                 ) : (
                     <HidUsageLabel
                         hid_usage={p.bindingParam1!}

--- a/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
+++ b/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
@@ -44,8 +44,14 @@ export function useStageBindings({
             header: p.header,
             // Tap glyph text (e.g. "Q", "Vol+") for legend sizing — mirrors what
             // HidUsageLabel renders, so KeyButton sizes the legend off the glyph
-            // length (design rule), not the action-type tag in `header`.
-            tapText: p.outOfRange ? '' : usageGlyph(p.bindingParam1!),
+            // length (design rule), not the action-type tag in `header`. For
+            // non-HID params (layer / enum / number) fall back to the firmware-
+            // resolved short text (e.g. "FN1", "BT 0", "Hue+").
+            tapText: p.outOfRange
+                ? ''
+                : p.bindingParam1 != null
+                  ? usageGlyph(p.bindingParam1)
+                  : (p.paramText ?? ''),
             actionLabel: p.actionLabel,
             holdTap: p.holdTap ? holdTapToLabels(p.holdTap) : undefined,
             // Chord modifiers (Ctrl/Shift/…) packed in the tap usage's high byte
@@ -84,6 +90,15 @@ export function useStageBindings({
             ry: p.ry,
             children: p.outOfRange ? (
                 <span></span>
+            ) : p.bindingParam1 == null && p.paramText ? (
+                // Non-HID param (layer / enum / number) — render the firmware's
+                // short text; there is no HID usage to draw a glyph from.
+                <span
+                    className="font-bold inline-flex items-center justify-center w-full leading-tight"
+                    title={p.paramTitle}
+                >
+                    {p.paramText}
+                </span>
             ) : (
                 <HidUsageLabel
                     hid_usage={p.bindingParam1!}
@@ -101,28 +116,32 @@ export function useStageBindings({
         encoderSlots.forEach((slot, i) => {
             const action = encoderActions[i]
             if (!action) return
-            // Two half-unit buttons side by side: ccw left, cw right.
+            // Two half-unit buttons side by side: ccw left, cw right. Prefer the
+            // short param text (e.g. "FN1", "BT 0") over the action-type name.
+            const ccwText =
+                action.ccw.label.paramText ?? action.ccw.label.primary
+            const cwText = action.cw.label.paramText ?? action.cw.label.primary
             encoderPositions.push({
                 id: `enc-${i}-ccw`,
                 header: 'CCW',
-                actionLabel: action.ccw.label.primary,
+                actionLabel: ccwText,
                 x: slot.x,
                 y: slot.y,
                 width: 0.5,
                 height: 1,
                 encoder: { slot: i, dir: 'ccw' },
-                children: <span>{action.ccw.label.primary}</span>,
+                children: <span>{ccwText}</span>,
             })
             encoderPositions.push({
                 id: `enc-${i}-cw`,
                 header: 'CW',
-                actionLabel: action.cw.label.primary,
+                actionLabel: cwText,
                 x: slot.x + 0.5,
                 y: slot.y,
                 width: 0.5,
                 height: 1,
                 encoder: { slot: i, dir: 'cw' },
-                children: <span>{action.cw.label.primary}</span>,
+                children: <span>{cwText}</span>,
             })
         })
         return [...keyPositions, ...encoderPositions]


### PR DESCRIPTION
Closes #147.

Consume the firmware's new `KeyLabel.paramText` so non-HID keycodes show their parameter on the keycap:
- momentary/toggle layer keys → layer name (e.g. `FN1`)
- `&bt` → command + profile (`BT 0`, `Disc 2`, `Clr`)
- RGB / backlight / output / mouse keys → short names / arrows

Falls back to the short text for the main legend, the tap glyph, and the device-preview snapshot; encoder caps prefer it over the action-type name.

## Notes
- Purely additive — caps with a HID usage are unchanged, and `paramText` is optional, so the app stays green against a firmware build that predates it.
- The legend logic lives in the firmware client; this PR is the renderer wiring only.

## Depends on
Wolffyx/remapprClientFirmware#4 — **merge that first**. App CI clones the firmware client's default branch (no ref pin), so the new `paramText` field only reaches CI once the firmware PR is on `main`.

## Verification
Local: 792 tests green, lint clean. (Pre-existing `@noble/*` failures in `src/firmware/remappr/*` are the known dependency-coupling gap on `main`, untouched here.)