### PR TITLE
feat(keymap): render param legends on advanced keycode caps

### DIFF
--- a/src/renderer/src/features/connection/DevicePreviewCapture.tsx
+++ b/src/renderer/src/features/connection/DevicePreviewCapture.tsx
@@ -40,7 +40,7 @@ export function DevicePreviewCapture(): null {
                     ? usageGlyph(p.holdTap!.tapParam)
                     : p.bindingParam1 != null
                       ? usageGlyph(p.bindingParam1)
-                      : (p.header ?? '')
+                      : (p.paramText ?? p.header ?? '')
                 const hold = p.holdTap
                     ? p.holdTap.holdNodeKind === 'layer'
                         ? (p.holdTap.holdLayerMomentary ?? '')

--- a/src/renderer/src/features/keymap/keyboard/HidUsageLabel.tsx
+++ b/src/renderer/src/features/keymap/keyboard/HidUsageLabel.tsx
@@ -1,8 +1,4 @@
-import {
-    hid_usage_get_labels,
-    hidUsagePageAndIdFromUsage,
-    usageGlyph,
-} from '@/lib/actions/hidUsages'
+import { hidUsageLongLabel, usageGlyph } from '@/lib/actions/hidUsages'
 import { glyphNode } from './keyGlyph'
 
 // pattern-check: skip — additive optional render flag on existing props interface
@@ -12,10 +8,6 @@ export interface HidUsageLabelProps {
     /** Suppress the inline modifier line (e.g. "CS") — used when the cap renders
      *  the chord modifiers as chips instead (KeyButton `mods`). */
     hideMods?: boolean
-}
-
-function remove_prefix(s?: string): string | undefined {
-    return s?.replace(/^Keyboard /, '')
 }
 
 const MOD_LABELS: Array<[number, string, string]> = [
@@ -42,12 +34,7 @@ export const HidUsageLabel = ({
     hid_usage,
     hideMods = false,
 }: HidUsageLabelProps): JSX.Element => {
-    const [pageMut, id] = hidUsagePageAndIdFromUsage(hid_usage)
-
-    const page = pageMut & 0xff
-
-    const labels = hid_usage_get_labels(page, id)
-    const baseLong = remove_prefix(labels.long || labels.med || labels.short)
+    const baseLong = hidUsageLongLabel(hid_usage)
     const mods = activeMods(hid_usage)
     const abbreviated = usageGlyph(hid_usage)
     const longTitle = mods.length

--- a/src/renderer/src/features/keymap/keyboard/KeyButton.tsx
+++ b/src/renderer/src/features/keymap/keyboard/KeyButton.tsx
@@ -379,11 +379,26 @@ const KeyButtonViewImpl = ({
     ].filter(Boolean)
     const tooltip = tooltipParts.join(' — ')
 
-    // Rich-tooltip rows (label → value); only non-empty rows render.
+    // Rich-tooltip rows (label → value); only non-empty rows render. Show the
+    // full breakdown of the binding rather than a single mislabelled line.
     const tipRows: Array<[string, string]> = []
-    if (header) tipRows.push(['Tap', header])
-    if (actionLabel) tipRows.push(['Action', actionLabel])
-    if (holdTap?.tooltip) tipRows.push(['Hold', holdTap.tooltip])
+    if (holdTap?.tooltip) {
+        // A tap-hold's tooltip already reads "<Action>\nTap: ..\nHold: ..";
+        // split it into labelled rows (first line = the action-type name).
+        holdTap.tooltip.split('\n').forEach((line, i) => {
+            const sep = line.indexOf(': ')
+            if (sep > 0) tipRows.push([line.slice(0, sep), line.slice(sep + 2)])
+            else if (i === 0 && line) tipRows.push(['Action', line])
+        })
+    } else {
+        // Header is the behaviour/action name (e.g. "To Layer", "Bluetooth",
+        // "Macro"); tapText is its value glyph/legend (e.g. "L4", "BT 0",
+        // "m_hello", "Q"). Both together read as the full key.
+        if (header) tipRows.push(['Action', header])
+        if (tapText && tapText !== header && tapText !== '▽')
+            tipRows.push(['Value', tapText])
+        if (actionLabel) tipRows.push(['Binding', actionLabel])
+    }
     const typeLabel = CATEGORY_META[category]?.label
     if (typeLabel) tipRows.push(['Type', typeLabel])
     if (pressCount != null) tipRows.push(['Presses', String(pressCount)])

--- a/src/renderer/src/features/keymap/keyboard/KeyButton.tsx
+++ b/src/renderer/src/features/keymap/keyboard/KeyButton.tsx
@@ -308,6 +308,7 @@ const KeyButtonViewImpl = ({
     seen = false,
     header,
     tapText,
+    valueTitle,
     actionLabel,
     oneU,
     hoverZoom = true,
@@ -395,8 +396,11 @@ const KeyButtonViewImpl = ({
         // "Macro"); tapText is its value glyph/legend (e.g. "L4", "BT 0",
         // "m_hello", "Q"). Both together read as the full key.
         if (header) tipRows.push(['Action', header])
-        if (tapText && tapText !== header && tapText !== '▽')
-            tipRows.push(['Value', tapText])
+        // Prefer the full, untruncated value (valueTitle) — the cap legend may be
+        // an abbreviated glyph (e.g. "Erro…") while the tooltip shows it whole.
+        const valueText = valueTitle ?? tapText
+        if (valueText && valueText !== header && valueText !== '▽')
+            tipRows.push(['Value', valueText])
         if (actionLabel) tipRows.push(['Binding', actionLabel])
     }
     const typeLabel = CATEGORY_META[category]?.label

--- a/src/renderer/src/features/keymap/keyboard/LayerKeyboardPreview.tsx
+++ b/src/renderer/src/features/keymap/keyboard/LayerKeyboardPreview.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { resolveBindingLabels, type ResolvedHoldTapDescriptor } from '@firmware'
 import { PhysicalLayoutCanvas, type KeyPosition } from './PhysicalLayoutCanvas'
 import { HidUsageLabel } from './HidUsageLabel'
+import { ParamLegend } from './ParamLegend'
 import type { HoldTapLabels } from './KeyButton'
 import { categoryForBinding } from '@/lib/keymap/keyCategory'
 import { useLayout } from '@/hooks/use-layouts'
@@ -72,12 +73,7 @@ export function LayerKeyboardPreview({
                 children: p.outOfRange ? (
                     <span />
                 ) : p.bindingParam1 == null && p.paramText ? (
-                    <span
-                        className="font-bold block w-full text-center leading-tight overflow-hidden text-ellipsis whitespace-nowrap"
-                        title={p.paramTitle}
-                    >
-                        {p.paramText}
-                    </span>
+                    <ParamLegend text={p.paramText} title={p.paramTitle} />
                 ) : (
                     <HidUsageLabel
                         hid_usage={p.bindingParam1!}

--- a/src/renderer/src/features/keymap/keyboard/LayerKeyboardPreview.tsx
+++ b/src/renderer/src/features/keymap/keyboard/LayerKeyboardPreview.tsx
@@ -71,6 +71,13 @@ export function LayerKeyboardPreview({
                 ry: p.ry,
                 children: p.outOfRange ? (
                     <span />
+                ) : p.bindingParam1 == null && p.paramText ? (
+                    <span
+                        className="font-bold inline-flex items-center justify-center w-full leading-tight"
+                        title={p.paramTitle}
+                    >
+                        {p.paramText}
+                    </span>
                 ) : (
                     <HidUsageLabel
                         hid_usage={p.bindingParam1!}

--- a/src/renderer/src/features/keymap/keyboard/LayerKeyboardPreview.tsx
+++ b/src/renderer/src/features/keymap/keyboard/LayerKeyboardPreview.tsx
@@ -73,7 +73,7 @@ export function LayerKeyboardPreview({
                     <span />
                 ) : p.bindingParam1 == null && p.paramText ? (
                     <span
-                        className="font-bold inline-flex items-center justify-center w-full leading-tight"
+                        className="font-bold block w-full text-center leading-tight overflow-hidden text-ellipsis whitespace-nowrap"
                         title={p.paramTitle}
                     >
                         {p.paramText}

--- a/src/renderer/src/features/keymap/keyboard/ParamLegend.tsx
+++ b/src/renderer/src/features/keymap/keyboard/ParamLegend.tsx
@@ -1,0 +1,22 @@
+// pattern-check: skip — one shared presentational span, extracted to dedupe
+
+/** The cap legend for a non-HID parameter (layer name, enum text, macro name).
+ *  Renders as a block that clips over-long text to an ellipsis, while `title`
+ *  carries the full value for the native tooltip. Shared by the editor stage
+ *  and the layout preview so the two render identically. */
+export function ParamLegend({
+    text,
+    title,
+}: {
+    text: string
+    title?: string
+}): JSX.Element {
+    return (
+        <span
+            className="font-bold block w-full text-center leading-tight overflow-hidden text-ellipsis whitespace-nowrap"
+            title={title}
+        >
+            {text}
+        </span>
+    )
+}

--- a/src/renderer/src/features/keymap/keyboard/PhysicalLayoutCanvas.tsx
+++ b/src/renderer/src/features/keymap/keyboard/PhysicalLayoutCanvas.tsx
@@ -38,6 +38,8 @@ export type KeyPosition = PropsWithChildren<{
     id?: string
     header?: string
     tapText?: string
+    /** Full value for the hover tooltip when tapText is an abbreviated glyph. */
+    valueTitle?: string
     actionLabel?: string
     holdTap?: HoldTapLabels
     /** Chord modifier names (e.g. ["Ctrl","Shift"]) → chips above the legend. */

--- a/src/renderer/src/features/keymap/keyboard/keyCapLegend.ts
+++ b/src/renderer/src/features/keymap/keyboard/keyCapLegend.ts
@@ -20,6 +20,9 @@ export interface KeyCapLegend {
     /** The tap glyph text (e.g. "Q", "Vol+") — also sizes the main legend
      * (≤1 char → 0.46U, ≤3 → 0.34U, else 0.24U). Distinct from {@link header}. */
     tapText?: string
+    /** Full, untruncated value for the hover tooltip (e.g. "ErrorUndefined"
+     *  when {@link tapText} is the abbreviated glyph). Falls back to tapText. */
+    valueTitle?: string
     /** Firmware binding code (e.g. "&kp" / "KC") shown as the header in
      *  "Binding code" display mode. */
     actionLabel?: string

--- a/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
+++ b/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
@@ -3,8 +3,7 @@ import { useMemo } from 'react'
 import type { Keymap } from '@firmware/types'
 import { resolveBindingLabels } from '@firmware'
 import {
-    hid_usage_get_labels,
-    hidUsagePageAndIdFromUsage,
+    hidUsageLongLabel,
     usageGlyph,
     usageModifierNames,
 } from '@/lib/actions/hidUsages'
@@ -15,16 +14,8 @@ import {
 import { HidUsageLabel } from '../HidUsageLabel'
 import type { KeyPosition } from '../PhysicalLayoutCanvas'
 import type { KeypressDetectionConfig } from '@/lib/keypress/keypressDetector'
+import { ParamLegend } from '../ParamLegend'
 import { holdTapToLabels } from './helpers'
-
-/** Full, human-readable HID key name for the hover tooltip (usageGlyph gives an
- *  abbreviated cap glyph; this keeps the whole name, e.g. "ErrorUndefined"). */
-function fullUsageLabel(usage: number): string | undefined {
-    const [pageMut, id] = hidUsagePageAndIdFromUsage(usage)
-    const labels = hid_usage_get_labels(pageMut & 0xff, id)
-    const long = labels.long || labels.med || labels.short
-    return long ? long.replace(/^Keyboard /, '') : undefined
-}
 
 interface Inputs {
     layouts: KeypressDetectionConfig['layouts'] | undefined
@@ -70,7 +61,7 @@ export function useStageBindings({
             // (HID keys). Param legends already carry their full text in tapText.
             valueTitle:
                 !p.outOfRange && p.bindingParam1 != null
-                    ? fullUsageLabel(p.bindingParam1)
+                    ? hidUsageLongLabel(p.bindingParam1)
                     : undefined,
             actionLabel: p.actionLabel,
             holdTap: p.holdTap ? holdTapToLabels(p.holdTap) : undefined,
@@ -111,15 +102,7 @@ export function useStageBindings({
             children: p.outOfRange ? (
                 <span></span>
             ) : p.bindingParam1 == null && p.paramText ? (
-                // Non-HID param (layer / enum / number / macro name) — render the
-                // firmware's short text; there is no HID usage to draw a glyph
-                // from. Clip an over-long name to an ellipsis like the other caps.
-                <span
-                    className="font-bold block w-full text-center leading-tight overflow-hidden text-ellipsis whitespace-nowrap"
-                    title={p.paramTitle}
-                >
-                    {p.paramText}
-                </span>
+                <ParamLegend text={p.paramText} title={p.paramTitle} />
             ) : (
                 <HidUsageLabel
                     hid_usage={p.bindingParam1!}

--- a/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
+++ b/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
@@ -91,10 +91,11 @@ export function useStageBindings({
             children: p.outOfRange ? (
                 <span></span>
             ) : p.bindingParam1 == null && p.paramText ? (
-                // Non-HID param (layer / enum / number) — render the firmware's
-                // short text; there is no HID usage to draw a glyph from.
+                // Non-HID param (layer / enum / number / macro name) — render the
+                // firmware's short text; there is no HID usage to draw a glyph
+                // from. Clip an over-long name to an ellipsis like the other caps.
                 <span
-                    className="font-bold inline-flex items-center justify-center w-full leading-tight"
+                    className="font-bold block w-full text-center leading-tight overflow-hidden text-ellipsis whitespace-nowrap"
                     title={p.paramTitle}
                 >
                     {p.paramText}

--- a/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
+++ b/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
@@ -2,7 +2,12 @@
 import { useMemo } from 'react'
 import type { Keymap } from '@firmware/types'
 import { resolveBindingLabels } from '@firmware'
-import { usageGlyph, usageModifierNames } from '@/lib/actions/hidUsages'
+import {
+    hid_usage_get_labels,
+    hidUsagePageAndIdFromUsage,
+    usageGlyph,
+    usageModifierNames,
+} from '@/lib/actions/hidUsages'
 import {
     categoryForBinding,
     faceCategoryForBinding,
@@ -11,6 +16,15 @@ import { HidUsageLabel } from '../HidUsageLabel'
 import type { KeyPosition } from '../PhysicalLayoutCanvas'
 import type { KeypressDetectionConfig } from '@/lib/keypress/keypressDetector'
 import { holdTapToLabels } from './helpers'
+
+/** Full, human-readable HID key name for the hover tooltip (usageGlyph gives an
+ *  abbreviated cap glyph; this keeps the whole name, e.g. "ErrorUndefined"). */
+function fullUsageLabel(usage: number): string | undefined {
+    const [pageMut, id] = hidUsagePageAndIdFromUsage(usage)
+    const labels = hid_usage_get_labels(pageMut & 0xff, id)
+    const long = labels.long || labels.med || labels.short
+    return long ? long.replace(/^Keyboard /, '') : undefined
+}
 
 interface Inputs {
     layouts: KeypressDetectionConfig['layouts'] | undefined
@@ -52,6 +66,12 @@ export function useStageBindings({
                 : p.bindingParam1 != null
                   ? usageGlyph(p.bindingParam1)
                   : (p.paramText ?? ''),
+            // Full value for the tooltip when the cap glyph is abbreviated
+            // (HID keys). Param legends already carry their full text in tapText.
+            valueTitle:
+                !p.outOfRange && p.bindingParam1 != null
+                    ? fullUsageLabel(p.bindingParam1)
+                    : undefined,
             actionLabel: p.actionLabel,
             holdTap: p.holdTap ? holdTapToLabels(p.holdTap) : undefined,
             // Chord modifiers (Ctrl/Shift/…) packed in the tap usage's high byte

--- a/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
+++ b/src/renderer/src/features/keymap/keyboard/stage/useStageBindings.tsx
@@ -44,8 +44,14 @@ export function useStageBindings({
             header: p.header,
             // Tap glyph text (e.g. "Q", "Vol+") for legend sizing — mirrors what
             // HidUsageLabel renders, so KeyButton sizes the legend off the glyph
-            // length (design rule), not the action-type tag in `header`.
-            tapText: p.outOfRange ? '' : usageGlyph(p.bindingParam1!),
+            // length (design rule), not the action-type tag in `header`. For
+            // non-HID params (layer / enum / number) fall back to the firmware-
+            // resolved short text (e.g. "FN1", "BT 0", "Hue+").
+            tapText: p.outOfRange
+                ? ''
+                : p.bindingParam1 != null
+                  ? usageGlyph(p.bindingParam1)
+                  : (p.paramText ?? ''),
             actionLabel: p.actionLabel,
             holdTap: p.holdTap ? holdTapToLabels(p.holdTap) : undefined,
             // Chord modifiers (Ctrl/Shift/…) packed in the tap usage's high byte
@@ -84,6 +90,15 @@ export function useStageBindings({
             ry: p.ry,
             children: p.outOfRange ? (
                 <span></span>
+            ) : p.bindingParam1 == null && p.paramText ? (
+                // Non-HID param (layer / enum / number) — render the firmware's
+                // short text; there is no HID usage to draw a glyph from.
+                <span
+                    className="font-bold inline-flex items-center justify-center w-full leading-tight"
+                    title={p.paramTitle}
+                >
+                    {p.paramText}
+                </span>
             ) : (
                 <HidUsageLabel
                     hid_usage={p.bindingParam1!}
@@ -101,28 +116,32 @@ export function useStageBindings({
         encoderSlots.forEach((slot, i) => {
             const action = encoderActions[i]
             if (!action) return
-            // Two half-unit buttons side by side: ccw left, cw right.
+            // Two half-unit buttons side by side: ccw left, cw right. Prefer the
+            // short param text (e.g. "FN1", "BT 0") over the action-type name.
+            const ccwText =
+                action.ccw.label.paramText ?? action.ccw.label.primary
+            const cwText = action.cw.label.paramText ?? action.cw.label.primary
             encoderPositions.push({
                 id: `enc-${i}-ccw`,
                 header: 'CCW',
-                actionLabel: action.ccw.label.primary,
+                actionLabel: ccwText,
                 x: slot.x,
                 y: slot.y,
                 width: 0.5,
                 height: 1,
                 encoder: { slot: i, dir: 'ccw' },
-                children: <span>{action.ccw.label.primary}</span>,
+                children: <span>{ccwText}</span>,
             })
             encoderPositions.push({
                 id: `enc-${i}-cw`,
                 header: 'CW',
-                actionLabel: action.cw.label.primary,
+                actionLabel: cwText,
                 x: slot.x + 0.5,
                 y: slot.y,
                 width: 0.5,
                 height: 1,
                 encoder: { slot: i, dir: 'cw' },
-                children: <span>{action.cw.label.primary}</span>,
+                children: <span>{cwText}</span>,
             })
         })
         return [...keyPositions, ...encoderPositions]

--- a/src/renderer/src/lib/actions/hidUsages.ts
+++ b/src/renderer/src/lib/actions/hidUsages.ts
@@ -51,6 +51,19 @@ export const hid_usage_get_labels = (
     }
 
 /**
+ * Full, human-readable label for a HID usage (e.g. "ErrorUndefined", "Volume
+ * Up") with the leading "Keyboard " noun stripped. Unlike {@link usageGlyph} it
+ * never abbreviates — used for hover tooltips where the whole name should show.
+ * Shared by `HidUsageLabel` and the editor stage so both resolve names the same.
+ */
+export const hidUsageLongLabel = (usage: number): string | undefined => {
+    const [page, id] = hidUsagePageAndIdFromUsage(usage)
+    const labels = hid_usage_get_labels(page & 0xff, id)
+    const long = labels.long || labels.med || labels.short
+    return long ? long.replace(/^Keyboard /, '') : undefined
+}
+
+/**
  * Resolve a HID usage to its short display glyph (e.g. "Q", "Tab", "Esc").
  * The single source of truth shared by `HidUsageLabel` (live caps) and the
  * device-preview snapshot (serializable cached legends) so both stay in sync.


### PR DESCRIPTION
Consume the firmware's new KeyLabel.paramText so non-HID keycodes show their parameter on the keycap (Wolffyx/remappr#147): momentary/toggle layer keys show the layer name, &bt shows command + profile, RGB/backlight /output/mouse keys show short names. Falls back to the short text for the main legend, the tap glyph, and the device-preview snapshot; encoder caps prefer it over the action-type name. Purely additive — caps with a HID usage are unchanged, and the field is optional so the app stays green against a firmware build that predates it.