### PR TITLE
fix(actions): BT profile param dropdown — show value, one-based (1–5), simplified

### DIFF
--- a/src/renderer/src/features/actions/KeyActionPicker.tsx
+++ b/src/renderer/src/features/actions/KeyActionPicker.tsx
@@ -181,7 +181,11 @@ export const KeyActionPicker = ({
             valueLabel:
                 slot.kind === 'enum' || slot.kind === 'modifier'
                     ? slot.values?.find((v) => v.value === params[i])?.label
-                    : undefined,
+                    : slot.kind === 'number' && slot.oneBased
+                      ? // Profile index is 0-based on the wire; the chip counts
+                        // from 1 to match the dropdown (and shows 0 → "1", not "—").
+                        String((params[i] ?? 0) + 1)
+                      : undefined,
             layerName: layerNameFor(params[i]),
             inactiveBorderClass: i === 0 ? 'border-secondary' : 'border-accent',
             onRemove: (): void => {

--- a/src/renderer/src/features/actions/SlotValuePicker.tsx
+++ b/src/renderer/src/features/actions/SlotValuePicker.tsx
@@ -61,7 +61,15 @@ export const SlotValuePicker = ({
                         id="slotValuePickerLayer"
                         className="w-[180px]"
                     >
-                        <SelectValue placeholder="Layer" />
+                        {/* Explicit children: Radix only fills the trigger from a
+                            mounted selected item, so a programmatically-set value
+                            on a never-opened Select (and value 0 in particular)
+                            renders blank. Render the label ourselves. */}
+                        <SelectValue placeholder="Layer">
+                            {value !== undefined
+                                ? layers.find((l) => l.id === value)?.name
+                                : undefined}
+                        </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                         {layers.map(({ id, name }) => (
@@ -97,7 +105,12 @@ export const SlotValuePicker = ({
                             id="slotValuePickerRange"
                             className="w-[180px]"
                         >
-                            <SelectValue placeholder={slot.label} />
+                            {/* Explicit children: without them Radix leaves the
+                                trigger blank for a seeded, never-opened value —
+                                notably profile 0 (a valid BT_SEL/BT_DISC index). */}
+                            <SelectValue placeholder={slot.label}>
+                                {value !== undefined ? value : undefined}
+                            </SelectValue>
                         </SelectTrigger>
                         <SelectContent>
                             {options.map((n) => (
@@ -136,7 +149,13 @@ export const SlotValuePicker = ({
                 value={value?.toString()}
             >
                 <SelectTrigger className="w-[180px]">
-                    <SelectValue placeholder={slot.label} />
+                    {/* Explicit children: render the chosen label ourselves so a
+                        seeded, never-opened command (incl. value 0) isn't blank. */}
+                    <SelectValue placeholder={slot.label}>
+                        {value !== undefined
+                            ? slot.values.find((v) => v.value === value)?.label
+                            : undefined}
+                    </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                     {slot.values.map((v) => (

--- a/src/renderer/src/features/actions/SlotValuePicker.tsx
+++ b/src/renderer/src/features/actions/SlotValuePicker.tsx
@@ -1,4 +1,6 @@
-// Pattern check: no GoF pattern (-) — rejected — dispatches by slot.kind to existing renderers (HID/layer/enum/number); no abstraction needed.
+// Pattern check: no GoF pattern (-) — rejected — DRYs three near-identical
+// Selects into one presentational component fed by a pure kind→config lookup;
+// data-driven dispatch over slot.kind, not polymorphic Strategy/Factory classes.
 import type { ActionSlot } from '@firmware/types'
 import type { KeycodeCodec } from '@firmware/codec'
 import type { KeyCatalog } from '@firmware/catalog/types'
@@ -12,6 +14,51 @@ import {
 } from '@/ui/select'
 import { Label } from '@/ui/label'
 import { Input } from '@/ui/input'
+import { type SelectConfig, selectConfigForSlot } from './selectConfigForSlot'
+
+// One Select for every value-list slot. The chosen option's label is passed as
+// explicit SelectValue children on purpose: Radix otherwise fills the trigger
+// only from a mounted item, so a seeded, never-opened value (notably 0) renders
+// blank. Rendering it ourselves keeps the trigger correct without an open.
+function ValueSelect({
+    value,
+    onChange,
+    options,
+    placeholder,
+    id,
+    label,
+}: SelectConfig & {
+    value?: number
+    onChange: (value?: number) => void
+}): JSX.Element {
+    const selected = options.find((o) => o.value === value)
+    const select = (
+        <Select
+            onValueChange={(e) => onChange(parseInt(e))}
+            value={value?.toString()}
+        >
+            <SelectTrigger id={id} className="w-[180px]">
+                <SelectValue placeholder={placeholder}>
+                    {selected ? selected.label : value?.toString()}
+                </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+                {options.map((o) => (
+                    <SelectItem key={o.value} value={o.value.toString()}>
+                        {o.label}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    )
+    if (!label) return select
+    return (
+        <>
+            <Label htmlFor={id}>{label}:</Label>
+            {select}
+        </>
+    )
+}
 
 // pattern-check: skip additive optional codec prop forwarded to the grid
 export interface SlotValuePickerProps {
@@ -49,122 +96,25 @@ export const SlotValuePicker = ({
         )
     }
 
-    if (slot.kind === 'layer') {
-        return (
-            <>
-                <Label htmlFor="slotValuePickerLayer">{slot.label}:</Label>
-                <Select
-                    onValueChange={(e) => onChange(parseInt(e))}
-                    value={value?.toString()}
-                >
-                    <SelectTrigger
-                        id="slotValuePickerLayer"
-                        className="w-[180px]"
-                    >
-                        {/* Explicit children: Radix only fills the trigger from a
-                            mounted selected item, so a programmatically-set value
-                            on a never-opened Select (and value 0 in particular)
-                            renders blank. Render the label ourselves. */}
-                        <SelectValue placeholder="Layer">
-                            {value !== undefined
-                                ? layers.find((l) => l.id === value)?.name
-                                : undefined}
-                        </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                        {layers.map(({ id, name }) => (
-                            <SelectItem key={id} value={id.toString()}>
-                                {name}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
-            </>
-        )
+    const config = selectConfigForSlot(slot, layers)
+    if (config) {
+        return <ValueSelect {...config} value={value} onChange={onChange} />
     }
 
     if (slot.kind === 'number' && slot.range) {
-        const range = slot.range
-        const span = range.max - range.min
-        // Small enumerable ranges (e.g. a BT profile index) render as a
-        // dropdown of every valid value — clearer than a free-form box and it
-        // can't hold an out-of-range entry. Wide ranges fall back to input.
-        if (span >= 0 && span <= 32) {
-            const options = Array.from(
-                { length: span + 1 },
-                (_, i) => range.min + i,
-            )
-            return (
-                <>
-                    <Label htmlFor="slotValuePickerRange">{slot.label}:</Label>
-                    <Select
-                        onValueChange={(e) => onChange(parseInt(e))}
-                        value={value?.toString()}
-                    >
-                        <SelectTrigger
-                            id="slotValuePickerRange"
-                            className="w-[180px]"
-                        >
-                            {/* Explicit children: without them Radix leaves the
-                                trigger blank for a seeded, never-opened value —
-                                notably profile 0 (a valid BT_SEL/BT_DISC index). */}
-                            <SelectValue placeholder={slot.label}>
-                                {value !== undefined ? value : undefined}
-                            </SelectValue>
-                        </SelectTrigger>
-                        <SelectContent>
-                            {options.map((n) => (
-                                <SelectItem key={n} value={n.toString()}>
-                                    {n}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                </>
-            )
-        }
+        // Wide range — no enumerable dropdown; fall back to a free numeric box.
         return (
             <>
                 <Label htmlFor="slotValuePickerRange">{slot.label}: </Label>
                 <Input
                     id="slotValuePickerRange"
                     type="number"
-                    min={range.min}
-                    max={range.max}
+                    min={slot.range.min}
+                    max={slot.range.max}
                     value={value ?? ''}
                     onChange={(e) => onChange(parseInt(e.target.value))}
                 />
             </>
-        )
-    }
-
-    if (
-        (slot.kind === 'enum' || slot.kind === 'modifier') &&
-        slot.values &&
-        slot.values.length > 0
-    ) {
-        return (
-            <Select
-                onValueChange={(e) => onChange(parseInt(e))}
-                value={value?.toString()}
-            >
-                <SelectTrigger className="w-[180px]">
-                    {/* Explicit children: render the chosen label ourselves so a
-                        seeded, never-opened command (incl. value 0) isn't blank. */}
-                    <SelectValue placeholder={slot.label}>
-                        {value !== undefined
-                            ? slot.values.find((v) => v.value === value)?.label
-                            : undefined}
-                    </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                    {slot.values.map((v) => (
-                        <SelectItem key={v.value} value={v.value.toString()}>
-                            {v.label}
-                        </SelectItem>
-                    ))}
-                </SelectContent>
-            </Select>
         )
     }
 

--- a/src/renderer/src/features/actions/selectConfigForSlot.test.ts
+++ b/src/renderer/src/features/actions/selectConfigForSlot.test.ts
@@ -1,0 +1,84 @@
+// Pattern check: no GoF pattern (-) — rejected — unit tests for the pure
+// slot→dropdown-config lookup; test code, no design pattern.
+import { describe, expect, it } from 'vitest'
+import type { ActionSlot } from '@firmware/types'
+import { selectConfigForSlot } from './selectConfigForSlot'
+
+const layers = [
+    { id: 0, name: 'Base' },
+    { id: 1, name: 'Fn' },
+]
+
+describe('selectConfigForSlot', () => {
+    it('maps a layer slot to id/name options with a label', () => {
+        const cfg = selectConfigForSlot(
+            { label: 'Layer', kind: 'layer' },
+            layers,
+        )
+        expect(cfg?.options).toEqual([
+            { value: 0, label: 'Base' },
+            { value: 1, label: 'Fn' },
+        ])
+        expect(cfg?.label).toBe('Layer')
+    })
+
+    it('maps an enum slot to its values and shows no leading label', () => {
+        const slot: ActionSlot = {
+            label: 'Command',
+            kind: 'enum',
+            values: [{ value: 3, label: 'BT_SEL' }],
+        }
+        const cfg = selectConfigForSlot(slot, layers)
+        expect(cfg?.options).toEqual([{ value: 3, label: 'BT_SEL' }])
+        expect(cfg?.label).toBeUndefined()
+    })
+
+    it('numbers a small range from range.min (0-based by default)', () => {
+        const slot: ActionSlot = {
+            label: 'profile',
+            kind: 'number',
+            range: { min: 0, max: 4 },
+        }
+        const cfg = selectConfigForSlot(slot, layers)
+        expect(cfg?.options).toEqual([
+            { value: 0, label: 0 },
+            { value: 1, label: 1 },
+            { value: 2, label: 2 },
+            { value: 3, label: 3 },
+            { value: 4, label: 4 },
+        ])
+    })
+
+    it('labels a one-based range from 1 while keeping the raw value', () => {
+        const slot: ActionSlot = {
+            label: 'profile',
+            kind: 'number',
+            range: { min: 0, max: 4 },
+            oneBased: true,
+        }
+        const cfg = selectConfigForSlot(slot, layers)
+        // value = stored 0-based index; label = user-facing 1-based number.
+        expect(cfg?.options).toEqual([
+            { value: 0, label: 1 },
+            { value: 1, label: 2 },
+            { value: 2, label: 3 },
+            { value: 3, label: 4 },
+            { value: 4, label: 5 },
+        ])
+    })
+
+    it('returns null for a wide range (free input) and non-list slots', () => {
+        expect(
+            selectConfigForSlot(
+                { label: 'n', kind: 'number', range: { min: 0, max: 255 } },
+                layers,
+            ),
+        ).toBeNull()
+        expect(
+            selectConfigForSlot({ label: 'k', kind: 'hid' }, layers),
+        ).toBeNull()
+        expect(
+            selectConfigForSlot({ label: 'a', kind: 'action' }, layers),
+        ).toBeNull()
+    })
+})

--- a/src/renderer/src/features/actions/selectConfigForSlot.ts
+++ b/src/renderer/src/features/actions/selectConfigForSlot.ts
@@ -1,0 +1,67 @@
+// pattern-check: skip — pure slot→dropdown-config lookup extracted from
+// SlotValuePicker so the component file only exports components (react-refresh).
+import type { ReactNode } from 'react'
+import type { ActionSlot } from '@firmware/types'
+
+export interface SelectOption {
+    value: number
+    label: ReactNode
+}
+
+export interface SelectConfig {
+    options: SelectOption[]
+    placeholder: string
+    /** Trigger id / htmlFor target; its presence also draws a leading Label. */
+    id?: string
+    label?: string
+}
+
+// The dropdown a slot renders as, or null when the slot is not a value list
+// (HID grid, wide numeric range, nested action). Centralising the per-kind
+// option lists here keeps the picker a single, shared Select.
+export function selectConfigForSlot(
+    slot: ActionSlot,
+    layers: { id: number; name: string }[],
+): SelectConfig | null {
+    if (slot.kind === 'layer') {
+        return {
+            id: 'slotValuePickerLayer',
+            label: slot.label,
+            placeholder: 'Layer',
+            options: layers.map((l) => ({ value: l.id, label: l.name })),
+        }
+    }
+    if (
+        (slot.kind === 'enum' || slot.kind === 'modifier') &&
+        slot.values &&
+        slot.values.length > 0
+    ) {
+        return {
+            placeholder: slot.label,
+            options: slot.values.map((v) => ({
+                value: v.value,
+                label: v.label,
+            })),
+        }
+    }
+    if (slot.kind === 'number' && slot.range) {
+        const { min, max } = slot.range
+        const span = max - min
+        // Small enumerable ranges (e.g. a BT profile index) render as a dropdown
+        // of every valid value — clearer than a free box and it can't hold an
+        // out-of-range entry. Wide ranges fall through to the numeric input.
+        if (span < 0 || span > 32) return null
+        return {
+            id: 'slotValuePickerRange',
+            label: slot.label,
+            placeholder: slot.label,
+            options: Array.from({ length: span + 1 }, (_, i) => {
+                const raw = min + i
+                // Store the raw index; label it one-based when the slot asks —
+                // a BT profile reads as 1..N though it is sent 0-based.
+                return { value: raw, label: slot.oneBased ? raw + 1 : raw }
+            }),
+        }
+    }
+    return null
+}


### PR DESCRIPTION
Two commits, both in the advanced-keycode param picker.

## 1. Blank profile dropdown (the reported bug)

`&bt` → `BT_SEL`/`BT_DISC` left the **profile** dropdown trigger blank even though a profile was selected. Not a falsy-`0` bug — `value?.toString()` returns `"0"` correctly. Radix fills the trigger text only from a *mounted* selected item, and `shouldShowPlaceholder` treats only `""`/`undefined` as empty, so a seeded, never-opened value (the auto-revealed profile) renders blank. Fixed by passing the selected label as explicit `SelectValue` children.

## 2. One-based profiles (1–5) + component cleanup

Follow-up from review feedback: profile `0` reads as a programming artifact. Profiles now display **1–5** while the stored/transmitted index stays **0–4** (ZMK `&bt BT_SEL 0` = first profile, unchanged).

- Firmware-agnostic: a new optional `ActionSlot.oneBased` flag drives the display; the picker, the SlotBar chip, and the cap legend all honour it. Adapters tag their profile slot — **requires the matching `remapprClientFirmware` change** (separate PR).
- The three near-identical layer / number / enum `Select` blocks are consolidated into one config-driven `ValueSelect` fed by a pure `selectConfigForSlot(slot)` lookup — fewer branches, and the trigger-children fix lives in one place.

## Test plan
- [ ] `&bt` → `BT_SEL` → profile dropdown shows **Profile 1** (not blank / not 0)
- [ ] Pick 1–5 → chip + cap legend match; stored index is 0–4
- [ ] Layer / command dropdowns unchanged
- [x] `pnpm typecheck` — pass
- [x] `eslint` — clean
- [x] full vitest — 843 pass (incl. new `selectConfigForSlot` + one-based label coverage)

> Depends on the `remapprClientFirmware` one-based tagging change; without it the UI degrades gracefully to 0-based.