### PR TITLE
fix(connection): clear stuck "Connecting" state on failed or hung connect

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -36,6 +36,11 @@ const SIDEBAR_STYLE = {
     '--footer-height': 'calc(var(--spacing) * 8)',
 } as React.CSSProperties
 
+// Abort a connection attempt whose adapter handshake never answers (e.g. a
+// silent / half-flashed device) so the UI recovers instead of hanging on
+// "Connecting" forever. Generous enough not to trip a slow-but-valid BLE link.
+const CONNECT_TIMEOUT_MS = 15_000
+
 function App(): JSX.Element {
     // pattern-check: skip — UI sweep, replace store-connection with store-service
     const {
@@ -43,7 +48,7 @@ function App(): JSX.Element {
         setService,
         setDeviceName,
         setLockState,
-        connectionAbort,
+        setConnectionAbort,
         lockState,
     } = useConnectionStore()
     const { reset } = undoRedoStore()
@@ -86,16 +91,26 @@ function App(): JSX.Element {
     const onConnect = async (
         t: Transport,
         communication: 'serial' | 'ble' | 'hid',
-    ): Promise<void> => {
+    ): Promise<boolean> => {
         const adapter = await pickAdapter(t, { transportKind: communication })
         if (!adapter) {
             toast.error('Failed to connect to the selected device.', {
                 description: 'No firmware adapter handled the device.',
             })
-            return
+            return false
         }
+        // Fresh controller per attempt: the handshake below can hang on a silent
+        // device, so a timeout aborts it (adapter.connect honours the signal).
+        // A previously-aborted controller would poison the retry, so publish a
+        // new one to the store — disconnect still aborts whichever is live.
+        const abort = new AbortController()
+        setConnectionAbort(abort)
+        const timeout = setTimeout(
+            () => abort.abort(new Error('Connection timed out')),
+            CONNECT_TIMEOUT_MS,
+        )
         try {
-            const next = await adapter.connect(t, connectionAbort.signal)
+            const next = await adapter.connect(t, abort.signal)
             // Re-apply a previously imported QMK/VIA/Keychron layout BEFORE the
             // service is exposed, so the first keymap read (Drawer) already
             // reflects it. Doing it here — rather than in a sibling effect —
@@ -121,10 +136,14 @@ function App(): JSX.Element {
                 rememberConnectedDeviceName(next.deviceInfo.name)
             }
             setService(next, communication)
+            return true
         } catch (err) {
             toast.error('Failed to connect to the selected device.', {
                 description: err instanceof Error ? err.message : String(err),
             })
+            return false
+        } finally {
+            clearTimeout(timeout)
         }
     }
 

--- a/src/renderer/src/features/connection/start-page/StartPage.tsx
+++ b/src/renderer/src/features/connection/start-page/StartPage.tsx
@@ -23,11 +23,12 @@ import { TransportSection } from './TransportSection'
 import { FeatureCard } from './FeatureCard'
 import { BuilderCard } from './BuilderCard'
 
+// pattern-check: skip mechanical return-type change on an existing prop (void → Promise<boolean>)
 interface StartPageProps {
     onTransportCreated: (
         t: Transport,
         communication: 'serial' | 'ble' | 'hid',
-    ) => void
+    ) => Promise<boolean>
     onDemoConnect?: () => void | Promise<void>
 }
 

--- a/src/renderer/src/hooks/use-connection.ts
+++ b/src/renderer/src/hooks/use-connection.ts
@@ -37,7 +37,9 @@ export function useConnection(
     onTransportCreated: (
         t: Transport,
         communication: 'serial' | 'ble' | 'hid',
-    ) => void,
+        // Resolves true once the adapter handshake succeeds, false when it
+        // fails/times out — lets the caller clear a device's "connecting" state.
+    ) => Promise<boolean>,
 ): UseConnectionResult {
     const transports = useMemo(() => getTransports(), [])
 
@@ -147,7 +149,15 @@ export function useConnection(
                     id: device.id,
                     label: device.label,
                 })
-                onTransportCreated(rpc, transport.communication)
+                // The transport opened, but the adapter handshake still runs
+                // inside onTransportCreated and can fail or hang there. Await it
+                // and, if it doesn't reach a connected service, drop the card
+                // back to "available" so it never sticks on "Connecting".
+                const connected = await onTransportCreated(
+                    rpc,
+                    transport.communication,
+                )
+                if (!connected) setStatus(device.id, 'available')
             } catch (e) {
                 console.error('Connection error:', e)
                 reportConnectError(
@@ -171,7 +181,7 @@ export function useConnection(
             try {
                 const rpc = await transport.connect()
                 useConnectionStore.getState().setLastConnectedDevice(null)
-                if (rpc) onTransportCreated(rpc, transport.communication)
+                if (rpc) await onTransportCreated(rpc, transport.communication)
             } catch (e) {
                 reportConnectError(
                     e,
@@ -191,7 +201,7 @@ export function useConnection(
             try {
                 const rpc = await transport.request_new()
                 useConnectionStore.getState().setLastConnectedDevice(null)
-                if (rpc) onTransportCreated(rpc, transport.communication)
+                if (rpc) await onTransportCreated(rpc, transport.communication)
             } catch (e) {
                 if (
                     e instanceof UserCancelledError ||


### PR DESCRIPTION
## Problem

Clicking **Connect** could leave the button stuck on "Connecting" forever when the connection didn't succeed.

## Root cause

`connect()` (`use-connection.ts`) set the device card to `connecting` and awaited only the **transport open**. The actual adapter handshake runs inside `onTransportCreated` (App's `onConnect`) and was invoked **fire-and-forget** — so when the handshake failed (no adapter, RPC error) or **hung** on a silent/half-flashed device, nothing ever reset the card's `connecting` status. `connect()`'s existing `catch` only covered the port-open reject, not the downstream handshake.

## Fix (renderer-only)

1. **Propagate the outcome.** `onConnect` now returns whether it reached a connected service. `connect()` awaits it and drops the card back to `available` when it doesn't — so a failed handshake no longer sticks (and the existing error toast still fires).
2. **Timeout the hang.** Each attempt runs under a fresh `AbortController` with a 15s timeout. `adapter.connect` honours the signal (`zmk/adapter.ts:111`), so a hanging handshake is aborted, rejects, and resets the UI. A fresh controller per attempt keeps a prior abort from poisoning the retry (the store's controller is only recreated on disconnect).

Files: `App.tsx`, `hooks/use-connection.ts`, `features/connection/start-page/StartPage.tsx` (prop type).

## Test plan
- [x] Connect to a device that fails the handshake → button returns to **Connect** + error toast (not stuck)
- [x] Connect to an unresponsive device → after ~15s, times out, button resets, "Connection timed out" toast
- [x] Retry after a failed attempt works (no poisoned abort)
- [x] Successful connect still opens the editor
- [x] `pnpm typecheck` — pass
- [x] `eslint` — clean
- [x] full vitest — 838 pass