### PR TITLE
fix(deps): add @noble/{ciphers,curves,hashes} for firmware auth.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
         "docs:preview": "vitepress preview docs"
     },
     "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "ms": "^2.1.3",
         "node-hid": "^3.3.0",
         "serialport": "^13.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,15 @@ importers:
 
   .:
     dependencies:
+      '@noble/ciphers':
+        specifier: ^2.2.0
+        version: 2.2.0
+      '@noble/curves':
+        specifier: ^2.2.0
+        version: 2.2.0
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       ms:
         specifier: ^2.1.3
         version: 2.1.3
@@ -1540,6 +1549,18 @@ packages:
 
   '@neoconfetti/react@1.0.0':
     resolution: {integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==}
+
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nornagon/put@0.0.8':
     resolution: {integrity: sha512-ugvXJjwF5ldtUpa7D95kruNJ41yFQDEKyF5CW4TgKJnh+W/zmlBzXXeKTyqIgwMFrkePN2JqOBqcF0M0oOunow==}
@@ -7300,6 +7321,14 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   '@neoconfetti/react@1.0.0': {}
+
+  '@noble/ciphers@2.2.0': {}
+
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@noble/hashes@2.2.0': {}
 
   '@nornagon/put@0.0.8':
     optional: true


### PR DESCRIPTION
The firmware sealed-control client (src/remappr/auth.ts, bundled into the app via the src/firmware symlink) imports @noble/curves, @noble/hashes and @noble/ciphers, but the app declared none of them — so vite/rollup could not resolve "@noble/curves/ed25519.js" and the web build failed. Add all three at firmware's ^2.2.0 range so the shared source resolves one noble major.

(cherry picked from commit 37726d26cf95b6651df893ed64d2a948f35b2bfb)