### PR TITLE
fix(build): exclude .remappr clone cache from packaged app

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -27,6 +27,10 @@ module.exports = {
     files: [
         '!**/.vscode/*',
         '!src/**',
+        // Build-time source cache from link-remappr.cjs — contains cloned repos
+        // whose committed symlinks dangle outside the app root; packaging them
+        // breaks the mac universal asar merge.
+        '!.remappr/**',
         '!.claude/**',
         '!.flowpatch/**',
         '!**/.flowpatch/**',


### PR DESCRIPTION
## Problem

`pnpm run build:mac` fails during the universal merge:

```
⨯ "React/zmk-studio-original/src/renderer/src/components" was not found in this archive  failedTask=build
    at Filesystem.getFile (@electron/asar/src/filesystem.ts:223:13)
    at mergeASARs (@electron/universal/src/asar-utils.ts:113:3)
```

## Cause

On CI, `link-remappr.cjs` clones the @remappr projects into `.remappr/`. The remapprBuilder clone contains committed symlinks (`src/components`, `src/stores`, …) whose targets are machine-specific relative paths (`../../../React/zmk-studio-original/...`). They dangle on CI, but the asar packer still records them as symlink entries. The mac **universal** build then merges the x64 and arm64 asars, and `@electron/universal` tries to resolve those link targets inside the archive — they point outside it, so the merge fails. Linux/Windows builds never run the asar merge, which is why only mac broke.

## Fix

Exclude `.remappr/**` from electron-builder `files`. The cache is build-time source only (vite already compiled it into `out/`); it never belongs in the packaged app. Also trims the asar, since entire cloned repos were being shipped.

Follow-up (separate task): remove the machine-specific symlinks from the remapprBuilder repo itself.