### PR TITLE
fix(build): don't package other-OS native prebuilds; fix universal check

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -94,6 +94,26 @@ jobs:
                   while IFS= read -r -d '' f; do
                     FOUND=1
                     case "$f" in
+                      # Prebuilds for other OSes are never Mach-O and never
+                      # load on macOS. Packaging excludes them (electron-builder
+                      # files patterns); warn on stragglers instead of failing
+                      # lipo on non-Mach-O files.
+                      */prebuilds/*linux*|*/prebuilds/*win32*|*/prebuilds/*android*|*/prebuilds/*freebsd*)
+                        echo "::warning::non-darwin prebuild packaged (should be excluded): $f"
+                        ;;
+                      # A darwin-x64+arm64 prebuild dir holds one fat binary —
+                      # verify it with lipo like any regular file.
+                      *darwin-x64+arm64*|*darwin-arm64+x64*|*darwin-universal*)
+                        ARCHS=$(lipo -archs "$f" 2>/dev/null || echo "unreadable")
+                        echo "$f -> $ARCHS"
+                        case "$ARCHS" in
+                          *x86_64*arm64*|*arm64*x86_64*) ;;
+                          *)
+                            echo "::error::not universal: $f ($ARCHS)"
+                            FAIL=1
+                            ;;
+                        esac
+                        ;;
                       # Per-arch prebuild dirs are single-arch by design —
                       # require the sibling arch to exist instead.
                       *darwin-x64*)

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -69,10 +69,15 @@ module.exports = {
         '!**/{.editorconfig,.eslintrc*,.prettierrc*,.npmignore,.travis.yml,.gitattributes,tsconfig*.json,.nycrc,karma.conf.js}',
         '!**/{.github,.idea,.vscode}/**',
         '!**/*.{ts.map,js.map,css.map}',
+        // Native-module prebuilds for platforms no desktop build targets.
+        '!**/prebuilds/*android*/**',
+        '!**/prebuilds/*freebsd*/**',
     ],
     asarUnpack: ['resources/**'],
     win: {
         executableName: 'app',
+        // Other-OS prebuilds are dead weight in the Windows package.
+        files: ['!**/prebuilds/*darwin*/**', '!**/prebuilds/*linux*/**'],
     },
     nsis: {
         artifactName: '${name}-electron-${version}-setup.${ext}',
@@ -128,6 +133,10 @@ module.exports = {
                 'Remappr uses Bluetooth to connect to keyboards over BLE.',
         },
         notarize: false,
+        // Other-OS prebuilds are not Mach-O: they can never load on macOS and
+        // they break the CI universal-lipo assertion (lipo reads them as
+        // "unreadable"). Strip them from the mac package.
+        files: ['!**/prebuilds/*linux*/**', '!**/prebuilds/*win32*/**'],
     },
     dmg: {
         artifactName: '${name}-electron-${version}.${ext}',
@@ -136,6 +145,8 @@ module.exports = {
         target: ['AppImage', 'deb', 'rpm', 'pacman', 'tar.gz'],
         maintainer: 'Wolffyx <wolffyx@wolffyx.com>',
         category: 'Utility',
+        // Other-OS prebuilds are dead weight in the Linux package.
+        files: ['!**/prebuilds/*darwin*/**', '!**/prebuilds/*win32*/**'],
     },
     appImage: {
         artifactName: '${name}-electron-${version}.${ext}',


### PR DESCRIPTION
Second half of the mac universal build fix — #171 was merged before this commit landed on its branch, so v0.0.14 still failed the "Verify universal macOS native modules" step (no mac dmg in the release).

## What failed on v0.0.14

The asar merge passed (#171 worked), but the CI universal check then flagged:

1. **Foreign-OS prebuilds** — node-hid + @serialport/bindings-cpp ship linux/win32/android `.node` prebuilds that were packaged into the mac app; `lipo` reads non-Mach-O files as "unreadable" → false failure. The actual mac binaries (`HID.node`, `bindings.node`) were correctly `x86_64 arm64`.
2. **`darwin-x64+arm64` case bug** — that prebuild dir holds one fat binary, but the check's `*darwin-x64*` branch matched it first and demanded a nonexistent `darwin-arm64+arm64` sibling.

## Fix

- electron-builder per-platform `files` excludes: mac drops `*linux*`/`*win32*` prebuilds, linux drops `*darwin*`/`*win32*`, win drops `*darwin*`/`*linux*`; `android`/`freebsd` dropped everywhere. Also shrinks every package.
- Check script: fat `darwin-x64+arm64` dirs go through the normal lipo check; straggler foreign prebuilds warn instead of erroring.

After merge, release-please will auto-cut the next release with both fixes; the broken v0.0.14 release has been deleted (tag kept).