### PR TITLE
feat: support dialog, Discord release workflow, profile restore, auto-connect

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -1,0 +1,71 @@
+name: discord-release
+
+# Announce every published (non-prerelease) GitHub Release to Discord.
+# release-please cuts the release on push to main, which fires this event —
+# same trigger build-release.yml uses.
+on:
+    release:
+        types: [published]
+
+permissions:
+    contents: read
+
+jobs:
+    announce:
+        name: Post release to Discord
+        runs-on: ubuntu-latest
+        # Webhook lives under the `remappr` environment (same as build-release);
+        # move it to a repo secret and drop this line if you prefer.
+        environment: remappr
+        if: ${{ !github.event.release.prerelease }}
+        steps:
+            - name: Post announcement
+              # Payload is built with jq (--arg) so the release body can never
+              # break out of the JSON, and the body is passed via env rather than
+              # interpolated into the shell.
+              env:
+                  DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+                  RELEASE_TAG: ${{ github.event.release.tag_name }}
+                  RELEASE_NAME: ${{ github.event.release.name }}
+                  RELEASE_URL: ${{ github.event.release.html_url }}
+                  RELEASE_BODY: ${{ github.event.release.body }}
+                  RELEASE_TIME: ${{ github.event.release.published_at }}
+              run: |
+                  set -euo pipefail
+
+                  if [ -z "${DISCORD_WEBHOOK_URL}" ]; then
+                    echo "::warning::DISCORD_WEBHOOK_URL is not set — skipping Discord announcement."
+                    exit 0
+                  fi
+
+                  TITLE="🚀 Remappr ${RELEASE_NAME:-$RELEASE_TAG} released"
+
+                  # Discord caps an embed description at 4096 chars; truncate with
+                  # a marker well under the limit.
+                  BODY="${RELEASE_BODY:-No release notes provided.}"
+                  if [ "${#BODY}" -gt 3900 ]; then
+                    BODY="${BODY:0:3900}"$'\n\n…truncated — see the full changelog on GitHub.'
+                  fi
+
+                  PAYLOAD=$(jq -n \
+                    --arg title "$TITLE" \
+                    --arg url "$RELEASE_URL" \
+                    --arg desc "$BODY" \
+                    --arg ts "$RELEASE_TIME" \
+                    '{
+                      username: "Remappr Releases",
+                      embeds: [ {
+                        title: $title,
+                        url: $url,
+                        description: $desc,
+                        color: 5793266,
+                        timestamp: $ts,
+                        footer: { text: "Remappr" }
+                      } ]
+                    }')
+
+                  # Fail the job on a non-2xx so a broken webhook is visible.
+                  curl -sS -f -X POST \
+                    -H "Content-Type: application/json" \
+                    -d "$PAYLOAD" \
+                    "$DISCORD_WEBHOOK_URL"

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ import { Toaster } from '@/ui/sonner'
 import { Header } from '@/layout/Header'
 import { AutoLayoutResolver } from '@/features/firmware/AutoLayoutResolver'
 import { DevicePreviewCapture } from '@/features/connection/DevicePreviewCapture'
+import { ProfileRestoreManager } from '@/features/connection/ProfileRestoreManager'
 // import { Footer } from '@/layout/Footer'
 import { ErrorBoundary } from '@/ui/ErrorBoundary'
 import { toast } from 'sonner'
@@ -243,6 +244,7 @@ function App(): JSX.Element {
                                         <Header />
                                         <AutoLayoutResolver />
                                         <DevicePreviewCapture />
+                                        <ProfileRestoreManager />
                                         <ErrorBoundary>
                                             <KeymapEditor />
                                         </ErrorBoundary>

--- a/src/renderer/src/components/modals/SupportModal.tsx
+++ b/src/renderer/src/components/modals/SupportModal.tsx
@@ -1,0 +1,100 @@
+// Pattern check: no GoF pattern (-) — rejected — presentational modal listing
+// external donation links; no abstraction or polymorphism warranted.
+import { useState } from 'react'
+// HandHeart + OPENCOLLECTIVE_URL re-added when the Open Collective row below is re-enabled.
+import { Coffee, Heart } from 'lucide-react'
+import { Modal } from '@/ui/modal'
+import { Button } from '@/ui/button'
+import { GitHubIcon } from '@/components/GitHubIcon'
+import { GITHUB_SPONSORS_URL, KOFI_URL } from '@/lib/constants'
+
+interface SupportOption {
+    name: string
+    blurb: string
+    url: string
+    icon: JSX.Element
+}
+
+const OPTIONS: SupportOption[] = [
+    {
+        name: 'GitHub Sponsors',
+        blurb: 'Sponsor development directly on GitHub.',
+        url: GITHUB_SPONSORS_URL,
+        icon: <GitHubIcon className="h-5 w-5" />,
+    },
+    {
+        name: 'Ko-fi',
+        blurb: 'Buy the project a coffee — one-off or monthly.',
+        url: KOFI_URL,
+        icon: <Coffee className="h-5 w-5" />,
+    },
+    // {
+    //     name: 'Open Collective',
+    //     blurb: 'Back the project transparently as a collective.',
+    //     url: OPENCOLLECTIVE_URL,
+    //     icon: <HandHeart className="h-5 w-5" />,
+    // },
+]
+
+/**
+ * Header entry point for donations. Renders its own trigger button (so it can be
+ * dropped into the header link cluster) and a controlled dialog listing every
+ * donation platform as an external link. Links open in the system browser in
+ * both web and Electron via the main-process setWindowOpenHandler.
+ */
+export function SupportModal(): JSX.Element {
+    const [open, setOpen] = useState(false)
+
+    return (
+        <>
+            <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Support this project"
+                onClick={(): void => setOpen(true)}
+            >
+                <Heart className="h-4 w-4" />
+            </Button>
+
+            <Modal
+                opened={open}
+                onClose={(): void => setOpen(false)}
+                title="Support this project"
+                subtitle="Help keep Remappr free and open-source"
+                headerIcon={<Heart />}
+                customModalBoxClass="w-11/12 max-w-md"
+                close="Close"
+                success={false}
+            >
+                <div className="flex flex-col gap-2 py-2">
+                    {OPTIONS.map((opt) => (
+                        <Button
+                            key={opt.name}
+                            variant="outline"
+                            asChild
+                            className="h-auto justify-start gap-3 px-3 py-3 text-left"
+                        >
+                            <a
+                                href={opt.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                <span className="grid size-9 shrink-0 place-items-center rounded-[10px] bg-primary/15 text-primary">
+                                    {opt.icon}
+                                </span>
+                                <span className="flex flex-col gap-0.5">
+                                    <span className="text-sm font-semibold">
+                                        {opt.name}
+                                    </span>
+                                    <span className="text-xs font-normal text-muted-foreground">
+                                        {opt.blurb}
+                                    </span>
+                                </span>
+                            </a>
+                        </Button>
+                    ))}
+                </div>
+            </Modal>
+        </>
+    )
+}

--- a/src/renderer/src/components/modals/settings/CommunicationSection.tsx
+++ b/src/renderer/src/components/modals/settings/CommunicationSection.tsx
@@ -55,6 +55,10 @@ export function CommunicationSection(): JSX.Element {
     const setAutoLoadLayout = useUserSettingsStore((s) => s.setAutoLoadLayout)
     const autosave = useUserSettingsStore((s) => s.autosave)
     const setAutosave = useUserSettingsStore((s) => s.setAutosave)
+    const autoRestoreProfile = useUserSettingsStore((s) => s.autoRestoreProfile)
+    const setAutoRestoreProfile = useUserSettingsStore(
+        (s) => s.setAutoRestoreProfile,
+    )
     // Adapters register lazily; recompute once they're loaded so the picker fills.
     const ready = useFirmwareClientsReady()
     const adapters = ready ? adaptersInCategory(category) : []
@@ -124,6 +128,27 @@ export function CommunicationSection(): JSX.Element {
                                 id="auto-save"
                                 checked={autosave}
                                 onCheckedChange={setAutosave}
+                            />
+                        </Field>
+                    </FieldLabel>
+                </FieldGroup>
+                <FieldGroup>
+                    <FieldLabel htmlFor="auto-restore-profile">
+                        <Field orientation="horizontal">
+                            <FieldContent>
+                                <FieldTitle>Auto-restore profile</FieldTitle>
+                                <FieldDescription>
+                                    Keep a backup of each keyboard&apos;s layout
+                                    and, when a keyboard reconnects wiped or
+                                    reset, restore it automatically instead of
+                                    asking. When off, Remappr prompts you before
+                                    restoring. Supported on ZMK today.
+                                </FieldDescription>
+                            </FieldContent>
+                            <Switch
+                                id="auto-restore-profile"
+                                checked={autoRestoreProfile}
+                                onCheckedChange={setAutoRestoreProfile}
                             />
                         </Field>
                     </FieldLabel>

--- a/src/renderer/src/features/connection/ProfileRestoreManager.tsx
+++ b/src/renderer/src/features/connection/ProfileRestoreManager.tsx
@@ -1,0 +1,186 @@
+// Pattern check: no GoF pattern (-) — rejected — headless effect component
+// (backup capture + wipe detection) plus a controlled prompt modal; no abstraction.
+import { useCallback, useEffect, useState } from 'react'
+import { RotateCcw } from 'lucide-react'
+import { Modal } from '@/ui/modal'
+import { Button } from '@/ui/button'
+import useConnectionStore from '@/stores/connectionStore'
+import useUserSettingsStore from '@/stores/userSettingsStore'
+import useProfileBackupStore, {
+    backupKey,
+    buildBackup,
+    keymapHash,
+    type ProfileBackup,
+} from '@/stores/profileBackupStore'
+import { applyRestore } from './applyRestore'
+import type { KeyboardService } from '@firmware/service'
+
+interface RestorePrompt {
+    backup: ProfileBackup
+    key: string
+    /** Live hash that triggered the prompt — stored on "don't ask" so the same
+     *  wiped state stays silent while a later change re-arms detection. */
+    liveHash: string
+}
+
+function supportsBackup(service: KeyboardService): boolean {
+    return (
+        !!service.capabilities.profileRestore && !service.capabilities.readOnly
+    )
+}
+
+/**
+ * Headless manager for per-device profile backup + restore. Mounted in the
+ * editor shell (like DevicePreviewCapture): captures a backup on connect and
+ * after every successful save, and — when a known device reconnects with a
+ * diverged/wiped keymap — either silently restores (auto-restore setting on) or
+ * prompts the user. Firmware-neutral; only devices whose adapter sets
+ * `capabilities.profileRestore` reach any of this.
+ */
+export function ProfileRestoreManager(): JSX.Element {
+    const service = useConnectionStore((s) => s.service)
+    const saveBackup = useProfileBackupStore((s) => s.saveBackup)
+    const setDismissedHash = useProfileBackupStore((s) => s.setDismissedHash)
+
+    const [prompt, setPrompt] = useState<RestorePrompt | null>(null)
+    const [restoring, setRestoring] = useState(false)
+
+    // pattern-check: skip — delegates restore side-effects to shared applyRestore
+    const doRestore = useCallback(
+        async (
+            svc: KeyboardService,
+            backup: ProfileBackup,
+            key: string,
+        ): Promise<void> => {
+            setRestoring(true)
+            try {
+                await applyRestore(svc, backup, key)
+            } finally {
+                setRestoring(false)
+            }
+        },
+        [],
+    )
+
+    // Detection + baseline capture, once per connected editable device.
+    useEffect(() => {
+        if (!service || !supportsBackup(service)) return
+        const svc = service
+        const key = backupKey(
+            svc,
+            useConnectionStore.getState().lastConnectedDevice?.id,
+        )
+        let cancelled = false
+
+        void (async () => {
+            let live
+            try {
+                live = await svc.getKeymap()
+            } catch {
+                return
+            }
+            if (cancelled) return
+            const liveHash = keymapHash(live)
+            const existing = useProfileBackupStore.getState().backups[key]
+
+            if (!existing) {
+                saveBackup(key, buildBackup(svc, live, Date.now()))
+                return
+            }
+            // In sync, or the user already dismissed this exact state.
+            if (existing.hash === liveHash) return
+            if (existing.dismissedHash === liveHash) return
+
+            if (useUserSettingsStore.getState().autoRestoreProfile) {
+                await doRestore(svc, existing, key)
+                return
+            }
+            setPrompt({ backup: existing, key, liveHash })
+        })()
+
+        return (): void => {
+            cancelled = true
+        }
+    }, [service, saveBackup, doRestore])
+
+    // Re-capture after every successful commit (pending true → false).
+    useEffect(() => {
+        if (!service || !supportsBackup(service)) return
+        const svc = service
+        const key = backupKey(
+            svc,
+            useConnectionStore.getState().lastConnectedDevice?.id,
+        )
+        let prevPending = svc.hasPendingChanges()
+        return svc.onPendingChangesChanged((pending) => {
+            const wasPending = prevPending
+            prevPending = pending
+            if (wasPending && !pending) {
+                svc.getKeymap()
+                    .then((km) =>
+                        saveBackup(key, buildBackup(svc, km, Date.now())),
+                    )
+                    .catch(() => {})
+            }
+        })
+    }, [service, saveBackup])
+
+    const savedAt = prompt
+        ? new Date(prompt.backup.savedAt).toLocaleString()
+        : ''
+
+    return (
+        <Modal
+            opened={!!prompt}
+            onClose={(): void => setPrompt(null)}
+            title="Restore your layout?"
+            subtitle={prompt ? `Last backed up ${savedAt}` : undefined}
+            headerIcon={<RotateCcw />}
+            customModalBoxClass="w-11/12 max-w-lg"
+            footer={
+                <div className="flex flex-wrap justify-end gap-2">
+                    <Button
+                        variant="ghost"
+                        disabled={restoring}
+                        onClick={(): void => {
+                            if (prompt)
+                                setDismissedHash(prompt.key, prompt.liveHash)
+                            setPrompt(null)
+                        }}
+                    >
+                        Don&apos;t ask for this device
+                    </Button>
+                    <Button
+                        variant="outline"
+                        disabled={restoring}
+                        onClick={(): void => setPrompt(null)}
+                    >
+                        Keep current
+                    </Button>
+                    <Button
+                        disabled={restoring || !service}
+                        onClick={(): void => {
+                            if (!prompt || !service) return
+                            const p = prompt
+                            setPrompt(null)
+                            void doRestore(service, p.backup, p.key)
+                        }}
+                    >
+                        Restore
+                    </Button>
+                </div>
+            }
+        >
+            <p className="py-2 text-sm text-muted-foreground">
+                This keyboard&apos;s current layout differs from your saved
+                backup
+                {prompt
+                    ? ` (${prompt.backup.keymap.layers.length} layers)`
+                    : ''}{' '}
+                — it may have been reset or wiped. Restoring overwrites the
+                keyboard&apos;s current layout with your backup and saves it to
+                the device.
+            </p>
+        </Modal>
+    )
+}

--- a/src/renderer/src/features/connection/applyRestore.ts
+++ b/src/renderer/src/features/connection/applyRestore.ts
@@ -1,0 +1,48 @@
+// Pattern check: no GoF pattern (-) — rejected — thin app-layer wrapper binding
+// restoreProfile to the stores + toasts; shared by the auto/prompt and manual
+// entry points so the side effects live in one place. No abstraction.
+import { toast } from 'sonner'
+import useConnectionStore from '@/stores/connectionStore'
+import useKeymapStore from '@/stores/keymapStore'
+import useProfileBackupStore, {
+    keymapHash,
+    type ProfileBackup,
+} from '@/stores/profileBackupStore'
+import { restoreProfile } from './restoreProfile'
+import type { KeyboardService } from '@firmware/service'
+
+/**
+ * Restore a backup to the live device and reconcile app state: refresh the
+ * editor keymap and sync the stored hash to the restored layout so detection
+ * treats the device as in-sync afterwards. Refuses when the device is locked.
+ * Returns true on success. Toasts on every outcome.
+ */
+export async function applyRestore(
+    service: KeyboardService,
+    backup: ProfileBackup,
+    key: string,
+): Promise<boolean> {
+    if (useConnectionStore.getState().lockState === 'locked') {
+        toast.error('Unlock the keyboard first, then restore its profile.')
+        return false
+    }
+    try {
+        const km = await restoreProfile(service, backup)
+        useKeymapStore.getState().setKeymap(km)
+        useProfileBackupStore.getState().saveBackup(key, {
+            ...backup,
+            hash: keymapHash(km),
+            dismissedHash: undefined,
+        })
+        const n = backup.keymap.layers.length
+        toast.success('Profile restored', {
+            description: `Recovered ${n} layer${n === 1 ? '' : 's'} to the keyboard.`,
+        })
+        return true
+    } catch (e) {
+        toast.error('Failed to restore profile', {
+            description: e instanceof Error ? e.message : String(e),
+        })
+        return false
+    }
+}

--- a/src/renderer/src/features/connection/device-menu/DeviceMenu.tsx
+++ b/src/renderer/src/features/connection/device-menu/DeviceMenu.tsx
@@ -9,10 +9,13 @@ import {
     Check,
     Cpu,
     Power,
+    RotateCcw,
     Settings as SettingsIcon,
+    Zap,
 } from 'lucide-react'
 import {
     DropdownMenu,
+    DropdownMenuCheckboxItem,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuLabel,
@@ -21,6 +24,9 @@ import {
 } from '@/ui/dropdown-menu'
 import { Settings } from '@/components/modals/Settings'
 import { toast } from 'sonner'
+import useUserSettingsStore from '@/stores/userSettingsStore'
+import useProfileBackupStore, { backupKey } from '@/stores/profileBackupStore'
+import { applyRestore } from '@/features/connection/applyRestore'
 import type { NodeView } from '@firmware/service'
 
 export const DeviceMenu = (): JSX.Element => {
@@ -36,6 +42,7 @@ export const DeviceMenu = (): JSX.Element => {
         disconnect,
         openNode,
         returnToParent,
+        lastConnectedDevice,
     } = useConnectionStore(
         useShallow((s) => ({
             service: s.service,
@@ -47,6 +54,7 @@ export const DeviceMenu = (): JSX.Element => {
             disconnect: s.disconnect,
             openNode: s.openNode,
             returnToParent: s.returnToParent,
+            lastConnectedDevice: s.lastConnectedDevice,
         })),
     )
     const reset = undoRedoStore((s) => s.reset)
@@ -61,6 +69,26 @@ export const DeviceMenu = (): JSX.Element => {
     const nodesApi = dongle?.nodes
     const viewingNode = !!parentService
     const readOnly = !!service?.capabilities.readOnly
+
+    // Profile restore (manual entry point) + auto-connect toggle state.
+    const autoConnectDeviceId = useUserSettingsStore(
+        (s) => s.autoConnectDeviceId,
+    )
+    const setAutoConnectDeviceId = useUserSettingsStore(
+        (s) => s.setAutoConnectDeviceId,
+    )
+    const backups = useProfileBackupStore((s) => s.backups)
+    const deviceKey = service
+        ? backupKey(service, lastConnectedDevice?.id)
+        : null
+    const backup = deviceKey ? backups[deviceKey] : undefined
+    const canRestore =
+        !readOnly && !!service?.capabilities.profileRestore && !!backup
+    // Only pick-and-connect devices carry an id we can auto-reconnect to; web
+    // simple-connect transports leave lastConnectedDevice null.
+    const autoConnectId = lastConnectedDevice?.id ?? null
+    const autoConnectOn =
+        !!autoConnectId && autoConnectDeviceId === autoConnectId
 
     const loadNodes = useCallback(async (): Promise<void> => {
         if (!nodesApi) {
@@ -226,6 +254,20 @@ export const DeviceMenu = (): JSX.Element => {
                         </>
                     )}
 
+                    {autoConnectId && (
+                        <DropdownMenuCheckboxItem
+                            checked={autoConnectOn}
+                            onCheckedChange={(checked): void =>
+                                setAutoConnectDeviceId(
+                                    checked ? autoConnectId : null,
+                                )
+                            }
+                            onSelect={(e): void => e.preventDefault()}
+                        >
+                            <Zap className="mr-2 h-4 w-4" />
+                            Auto-connect on launch
+                        </DropdownMenuCheckboxItem>
+                    )}
                     <DropdownMenuItem
                         onClick={disconnect}
                         className="text-destructive focus:text-destructive"
@@ -233,6 +275,21 @@ export const DeviceMenu = (): JSX.Element => {
                         <Power className="mr-2 h-4 w-4" />
                         Disconnect
                     </DropdownMenuItem>
+                    {canRestore && (
+                        <DropdownMenuItem
+                            onClick={(): void => {
+                                if (service && backup && deviceKey)
+                                    void applyRestore(
+                                        service,
+                                        backup,
+                                        deviceKey,
+                                    )
+                            }}
+                        >
+                            <RotateCcw className="mr-2 h-4 w-4" />
+                            Restore backup
+                        </DropdownMenuItem>
+                    )}
                     {!readOnly && (
                         <RestoreStockModal
                             onOk={(): void => {

--- a/src/renderer/src/features/connection/restoreProfile.test.ts
+++ b/src/renderer/src/features/connection/restoreProfile.test.ts
@@ -1,0 +1,193 @@
+// pattern-check: skip — test fixtures + mock service for restoreProfile, no abstraction
+import { describe, it, expect } from 'vitest'
+import type { Capabilities, KeyboardService } from '@firmware/service'
+import type { Keymap, KeyAction, KeyUpdate, Layer } from '@firmware/types'
+import { restoreProfile } from './restoreProfile'
+import type { ProfileBackup } from '@/stores/profileBackupStore'
+
+const ka = (kind: string, params: number[] = []): KeyAction =>
+    ({ kind, params }) as unknown as KeyAction
+
+const layer = (id: number, name: string, keys: KeyAction[]): Layer => ({
+    id,
+    name,
+    keys,
+})
+
+const km = (layers: Layer[], activeLayoutId = 0): Keymap => ({
+    layers,
+    availableLayers: 8,
+    activeLayoutId,
+    layouts: [],
+})
+
+const backupOf = (keymap: Keymap): ProfileBackup => ({
+    deviceName: 'Test',
+    firmware: 'zmk',
+    keymap,
+    hash: 'x',
+    savedAt: 0,
+})
+
+/** Stateful mock KeyboardService covering only what restoreProfile touches. */
+function makeService(
+    initial: Layer[],
+    caps?: Partial<Capabilities>,
+): {
+    service: KeyboardService
+    calls: string[]
+    setKeysBatches: KeyUpdate[][]
+    renamed: Array<[number, string]>
+} {
+    const state = {
+        layers: initial.map((l) => ({ ...l, keys: [...l.keys] })),
+        activeLayoutId: 0,
+    }
+    const calls: string[] = []
+    const setKeysBatches: KeyUpdate[][] = []
+    const renamed: Array<[number, string]> = []
+    let nextId = 100
+
+    const snapshot = (): Keymap => ({
+        layers: state.layers.map((l) => ({ ...l, keys: [...l.keys] })),
+        availableLayers: 8,
+        activeLayoutId: state.activeLayoutId,
+        layouts: [],
+    })
+    const keyWidth = (): number => state.layers[0]?.keys.length ?? 0
+
+    const svc = {
+        deviceInfo: { name: 'Test', firmware: 'zmk', serialNumber: 'S' },
+        capabilities: {
+            variableLayerCount: true,
+            rename: true,
+            ...caps,
+        } as Capabilities,
+        getKeymap: async () => {
+            calls.push('getKeymap')
+            return snapshot()
+        },
+        addLayer: async () => {
+            calls.push('addLayer')
+            const l = {
+                id: nextId++,
+                name: 'new',
+                keys: Array.from({ length: keyWidth() }, () => ka('trans')),
+            }
+            state.layers.push(l)
+            return l
+        },
+        removeLayer: async (id: number) => {
+            calls.push('removeLayer')
+            state.layers = state.layers.filter((l) => l.id !== id)
+        },
+        renameLayer: async (id: number, name: string) => {
+            calls.push('renameLayer')
+            renamed.push([id, name])
+            const l = state.layers.find((x) => x.id === id)
+            if (l) l.name = name
+        },
+        moveLayer: async () => {
+            calls.push('moveLayer')
+        },
+        setActivePhysicalLayout: async (layoutId: number) => {
+            calls.push('setActivePhysicalLayout')
+            state.activeLayoutId = layoutId
+            return snapshot()
+        },
+        setKeys: async (u: KeyUpdate[]) => {
+            calls.push('setKeys')
+            setKeysBatches.push(u)
+        },
+        commit: async () => {
+            calls.push('commit')
+        },
+    }
+    return {
+        service: svc as unknown as KeyboardService,
+        calls,
+        setKeysBatches,
+        renamed,
+    }
+}
+
+describe('restoreProfile', () => {
+    it('batches every binding then commits, in that order', async () => {
+        const { service, calls, setKeysBatches } = makeService([
+            layer(0, 'Base', [ka('kp', [4]), ka('kp', [5])]),
+        ])
+        const backup = backupOf(
+            km([layer(7, 'Base', [ka('kp', [20]), ka('kp', [21])])]),
+        )
+
+        await restoreProfile(service, backup)
+
+        expect(setKeysBatches).toHaveLength(1)
+        expect(setKeysBatches[0]).toEqual([
+            { layerId: 0, position: 0, action: ka('kp', [20]) },
+            { layerId: 0, position: 1, action: ka('kp', [21]) },
+        ])
+        // setKeys must precede commit.
+        expect(calls.indexOf('setKeys')).toBeLessThan(calls.indexOf('commit'))
+        expect(calls.filter((c) => c === 'commit')).toHaveLength(1)
+    })
+
+    it('adds missing layers and renames them to the backup', async () => {
+        const { service, calls, setKeysBatches, renamed } = makeService([
+            layer(0, 'Base', [ka('kp', [4]), ka('kp', [5])]),
+        ])
+        const backup = backupOf(
+            km([
+                layer(0, 'Base', [ka('kp', [20]), ka('kp', [21])]),
+                layer(1, 'Fn', [ka('kp', [30]), ka('kp', [31])]),
+            ]),
+        )
+
+        await restoreProfile(service, backup)
+
+        expect(calls).toContain('addLayer')
+        // One flat batch, two layers × two keys.
+        expect(setKeysBatches[0]).toHaveLength(4)
+        // The freshly-added layer (id 100) is renamed to the saved name.
+        expect(renamed).toContainEqual([100, 'Fn'])
+        expect(setKeysBatches[0]).toContainEqual({
+            layerId: 100,
+            position: 0,
+            action: ka('kp', [30]),
+        })
+    })
+
+    it('removes extra layers to match the backup', async () => {
+        const { service, calls, setKeysBatches } = makeService([
+            layer(0, 'Base', [ka('kp', [4])]),
+            layer(1, 'Fn', [ka('kp', [9])]),
+        ])
+        const backup = backupOf(km([layer(0, 'Base', [ka('kp', [20])])]))
+
+        await restoreProfile(service, backup)
+
+        expect(calls).toContain('removeLayer')
+        // Only the single remaining layer's key is written.
+        expect(setKeysBatches[0]).toEqual([
+            { layerId: 0, position: 0, action: ka('kp', [20]) },
+        ])
+    })
+
+    it('does not add/remove layers when the firmware lacks variableLayerCount', async () => {
+        const { service, calls } = makeService(
+            [layer(0, 'Base', [ka('kp', [4])])],
+            { variableLayerCount: false },
+        )
+        const backup = backupOf(
+            km([
+                layer(0, 'Base', [ka('kp', [20])]),
+                layer(1, 'Fn', [ka('kp', [30])]),
+            ]),
+        )
+
+        await restoreProfile(service, backup)
+
+        expect(calls).not.toContain('addLayer')
+        expect(calls).not.toContain('removeLayer')
+    })
+})

--- a/src/renderer/src/features/connection/restoreProfile.ts
+++ b/src/renderer/src/features/connection/restoreProfile.ts
@@ -1,0 +1,81 @@
+// Pattern check: no GoF pattern (-) — rejected — single linear async procedure
+// driving neutral KeyboardService ops; no abstraction or polymorphism warranted.
+import type { KeyboardService } from '@firmware/service'
+import type { Keymap, KeyUpdate } from '@firmware/types'
+import type { ProfileBackup } from '@/stores/profileBackupStore'
+
+/**
+ * Push a saved profile's full keymap back onto the live device, recovering a
+ * wiped/reset keyboard. Firmware-neutral: uses only the shared KeyboardService
+ * surface, so it works for any adapter whose `capabilities.profileRestore` is set.
+ *
+ * Steps: reconcile the device's layer set to the backup (add/remove/rename),
+ * match the saved physical layout, batch-write every binding via setKeys, then
+ * commit. Returns the fresh keymap so the caller can refresh the editor.
+ *
+ * The caller is responsible for ensuring the device is unlocked first.
+ * Encoder bindings are not restored in this pass (see keymapHash).
+ */
+export async function restoreProfile(
+    service: KeyboardService,
+    backup: ProfileBackup,
+): Promise<Keymap> {
+    const caps = service.capabilities
+    const saved = backup.keymap
+    let live = await service.getKeymap()
+
+    // 1. Reconcile layer count to the backup (only where the firmware supports it).
+    if (caps.variableLayerCount) {
+        while (live.layers.length < saved.layers.length) {
+            await service.addLayer()
+            live = await service.getKeymap()
+        }
+        while (live.layers.length > saved.layers.length) {
+            const last = live.layers[live.layers.length - 1]
+            await service.removeLayer(last.id)
+            live = await service.getKeymap()
+        }
+    }
+
+    // 2. Match the saved physical layout — this changes key positions/count, so
+    //    it must happen before we compute per-position updates.
+    if (saved.activeLayoutId !== live.activeLayoutId) {
+        try {
+            live = await service.setActivePhysicalLayout(saved.activeLayoutId)
+        } catch (e) {
+            console.warn('restoreProfile: failed to set physical layout', e)
+        }
+    }
+
+    // 3. Rename layers to match + build one flat batch of every binding. Layers
+    //    are matched by index (ids differ after a wipe); counts may still differ
+    //    if the firmware doesn't allow add/remove, so clamp to the overlap.
+    const updates: KeyUpdate[] = []
+    const layerCount = Math.min(saved.layers.length, live.layers.length)
+    for (let i = 0; i < layerCount; i++) {
+        const dev = live.layers[i]
+        const src = saved.layers[i]
+        if (caps.rename && dev.name !== src.name) {
+            try {
+                await service.renameLayer(dev.id, src.name)
+            } catch (e) {
+                console.warn('restoreProfile: failed to rename layer', e)
+            }
+        }
+        const keyCount = Math.min(src.keys.length, dev.keys.length)
+        for (let pos = 0; pos < keyCount; pos++) {
+            updates.push({
+                layerId: dev.id,
+                position: pos,
+                action: src.keys[pos],
+            })
+        }
+    }
+
+    // 4. Write the whole profile in one batch, then persist it to the device.
+    await service.setKeys(updates)
+    await service.commit()
+
+    // 5. Fresh read so the editor reflects the restored layout.
+    return service.getKeymap()
+}

--- a/src/renderer/src/features/connection/start-page/StartPage.tsx
+++ b/src/renderer/src/features/connection/start-page/StartPage.tsx
@@ -11,6 +11,7 @@ import { DownloadLatestButton } from '@/components/DownloadLatestButton'
 import { APP_VERSION, DISCORD_URL, DOCS_URL, REPO_URL } from '@/lib/constants'
 import { LicenseNoticeModal } from '@/components/modals/LicenseNoticeModal'
 import { Settings } from '@/components/modals/Settings'
+import { SupportModal } from '@/components/modals/SupportModal'
 import { WindowControls } from '@/layout/WindowControls'
 import { TrafficLightInset } from '@/layout/TrafficLightInset'
 import { useConnection } from '@/hooks/use-connection'
@@ -128,6 +129,16 @@ export function StartPage({
                         </TooltipTrigger>
                         <TooltipContent>
                             <p>Documentation</p>
+                        </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <div>
+                                <SupportModal />
+                            </div>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p>Support this project</p>
                         </TooltipContent>
                     </Tooltip>
                     {/* native window controls (Electron, non-mac) merged into

--- a/src/renderer/src/hooks/use-connection.ts
+++ b/src/renderer/src/hooks/use-connection.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { Transport } from '@firmware'
 import { UserCancelledError } from '@firmware'
-import type { TransportFactory } from '@/transport/types'
+import type { AvailableDevice, TransportFactory } from '@/transport/types'
 import { ensureFirmwareClientsLoaded } from '@/transport/adapter/firmwareClients'
 import { getTransports, subscribeToTransportChanges } from '@/lib/transports'
 import useConnectionStore from '@/stores/connectionStore'
@@ -160,6 +160,10 @@ export function useConnection(
 
     const connect = useCallback(
         async (target: DeviceWithTransport): Promise<void> => {
+            // Any connection this session disarms launch auto-connect, so a later
+            // manual disconnect can't trigger a reconnect (covers the auto-connect
+            // effect's own call too).
+            autoConnectAttempted = true
             const { device, transport } = target
             setConnectingDeviceId(device.id)
             setStatus(device.id, 'connecting')
@@ -199,6 +203,7 @@ export function useConnection(
                 toast.error('Transport not available')
                 return
             }
+            autoConnectAttempted = true
             try {
                 await ensureFirmwareClientsLoaded()
                 const rpc = await transport.connect()
@@ -220,10 +225,37 @@ export function useConnection(
                 toast.error('Pairing not supported for this transport')
                 return
             }
+            autoConnectAttempted = true
             try {
                 await ensureFirmwareClientsLoaded()
+                // Snapshot the granted list so we can identify the device the
+                // browser chooser just granted — pairing (request_new) otherwise
+                // yields no device id, which would hide the auto-connect toggle
+                // until the next reconnect.
+                const grantedBefore = transport.pick_and_connect
+                    ? new Set(
+                          (
+                              await transport.pick_and_connect
+                                  .list()
+                                  .catch(() => [])
+                          ).map((d) => d.id),
+                      )
+                    : null
                 const rpc = await transport.request_new()
-                useConnectionStore.getState().setLastConnectedDevice(null)
+                let paired: AvailableDevice | null = null
+                if (transport.pick_and_connect && grantedBefore) {
+                    const after = await transport.pick_and_connect
+                        .list()
+                        .catch(() => [])
+                    paired =
+                        after.find((d) => !grantedBefore.has(d.id)) ??
+                        (after.length === 1 ? after[0] : null)
+                }
+                useConnectionStore
+                    .getState()
+                    .setLastConnectedDevice(
+                        paired ? { id: paired.id, label: paired.label } : null,
+                    )
                 if (rpc) await onTransportCreated(rpc, transport.communication)
             } catch (e) {
                 if (

--- a/src/renderer/src/hooks/use-connection.ts
+++ b/src/renderer/src/hooks/use-connection.ts
@@ -7,10 +7,16 @@ import type { TransportFactory } from '@/transport/types'
 import { ensureFirmwareClientsLoaded } from '@/transport/adapter/firmwareClients'
 import { getTransports, subscribeToTransportChanges } from '@/lib/transports'
 import useConnectionStore from '@/stores/connectionStore'
+import useUserSettingsStore from '@/stores/userSettingsStore'
 import type {
     DeviceStatus,
     DeviceWithTransport,
 } from '@/features/connection/types'
+
+// One-shot per app process: StartPage (and this hook) unmount on connect and
+// remount on disconnect, so a per-mount ref would auto-reconnect right after a
+// manual disconnect. A module-level flag keeps auto-connect to the launch window.
+let autoConnectAttempted = false
 
 interface UseConnectionResult {
     transports: TransportFactory[]
@@ -63,6 +69,9 @@ export function useConnection(
     const [refreshing, setRefreshing] = useState(false)
     const [connectingDeviceId, setConnectingDeviceId] = useState<string | null>(
         null,
+    )
+    const autoConnectDeviceId = useUserSettingsStore(
+        (s) => s.autoConnectDeviceId,
     )
 
     // Scan generation counter: mount, transport changes, auto-scan events and
@@ -229,6 +238,27 @@ export function useConnection(
         },
         [onTransportCreated],
     )
+
+    // Auto-connect on launch: once the granted-device list arrives, connect the
+    // flagged device if it's present and nothing is connected. Fires at most once
+    // per app process (module flag) so a manual disconnect never triggers a
+    // reconnect. Reconnecting a granted device needs no permission prompt.
+    useEffect(() => {
+        if (autoConnectAttempted) return
+        // Already connected (manual or a prior auto-connect) — disarm.
+        if (useConnectionStore.getState().service) {
+            autoConnectAttempted = true
+            return
+        }
+        if (!autoConnectDeviceId) return
+        if (connectingDeviceIdRef.current !== null) return
+        const match = devices.find((d) => d.device.id === autoConnectDeviceId)
+        if (!match) return
+        autoConnectAttempted = true
+        // Defer out of the effect body so the connect's setState doesn't
+        // cascade a render synchronously (react-hooks/set-state-in-effect).
+        queueMicrotask(() => void connect(match))
+    }, [devices, autoConnectDeviceId, connect])
 
     return {
         transports,

--- a/src/renderer/src/layout/Header.tsx
+++ b/src/renderer/src/layout/Header.tsx
@@ -40,6 +40,7 @@ import useLiveViewStore from '@/stores/liveViewStore'
 import useKeyTestStore from '@/stores/keyTestStore'
 import useLoadStatsStore from '@/stores/loadStatsStore'
 import { Settings } from '../components/modals/Settings.tsx'
+import { SupportModal } from '../components/modals/SupportModal.tsx'
 import { Download as DownloadModal } from '../components/modals/Download.tsx'
 import { SidebarTrigger, useSidebar } from '@/ui/sidebar'
 import { Button } from '@/ui/button'
@@ -679,6 +680,16 @@ export function Header(): JSX.Element {
                     </TooltipTrigger>
                     <TooltipContent>
                         <p>Documentation</p>
+                    </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <div>
+                            <SupportModal />
+                        </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        <p>Support this project</p>
                     </TooltipContent>
                 </Tooltip>
 

--- a/src/renderer/src/lib/constants.ts
+++ b/src/renderer/src/lib/constants.ts
@@ -4,5 +4,11 @@ export const GITHUB_REPO = 'remappr'
 export const REPO_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`
 export const DISCORD_URL = 'https://discord.gg/asJ7bCCMzW'
 export const DOCS_URL = 'https://docs.remappr.com'
+// Donation links surfaced in the "Support this project" dialog. GitHub Sponsors
+// derives from the repo owner; the Ko-fi handle / Open Collective slug are
+// placeholders — confirm the real ones before release.
+export const GITHUB_SPONSORS_URL = `https://github.com/sponsors/${GITHUB_OWNER}`
+export const KOFI_URL = 'https://ko-fi.com/wolffyx'
+export const OPENCOLLECTIVE_URL = 'https://opencollective.com/remappr'
 export const APP_VERSION =
     typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0'

--- a/src/renderer/src/stores/profileBackupStore.test.ts
+++ b/src/renderer/src/stores/profileBackupStore.test.ts
@@ -1,0 +1,143 @@
+// pattern-check: skip — test fixtures for backup hash/key helpers, no abstraction
+import { describe, it, expect } from 'vitest'
+import type { KeyboardService } from '@firmware/service'
+import type { Keymap, KeyAction, Layer } from '@firmware/types'
+import {
+    backupKey,
+    buildBackup,
+    isPortableKey,
+    keymapHash,
+} from './profileBackupStore'
+
+const ka = (kind: string, params: number[] = []): KeyAction =>
+    ({ kind, params }) as unknown as KeyAction
+
+const layer = (id: number, name: string, keys: KeyAction[]): Layer => ({
+    id,
+    name,
+    keys,
+})
+
+const km = (layers: Layer[], activeLayoutId = 0): Keymap => ({
+    layers,
+    availableLayers: 8,
+    activeLayoutId,
+    layouts: [],
+})
+
+const svc = (deviceInfo: {
+    serialNumber?: string
+    name?: string
+    vid?: number
+    pid?: number
+}): KeyboardService =>
+    ({
+        deviceInfo: { firmware: 'zmk', ...deviceInfo },
+    }) as unknown as KeyboardService
+
+describe('keymapHash', () => {
+    it('ignores layer ids (stable across id reassignment)', () => {
+        const a = km([layer(0, 'Base', [ka('kp', [4]), ka('kp', [5])])])
+        const b = km([layer(42, 'Base', [ka('kp', [4]), ka('kp', [5])])])
+        expect(keymapHash(a)).toBe(keymapHash(b))
+    })
+
+    it('changes when a binding changes', () => {
+        const a = km([layer(0, 'Base', [ka('kp', [4])])])
+        const b = km([layer(0, 'Base', [ka('kp', [6])])])
+        expect(keymapHash(a)).not.toBe(keymapHash(b))
+    })
+
+    it('changes when a layer is renamed', () => {
+        const a = km([layer(0, 'Base', [ka('kp', [4])])])
+        const b = km([layer(0, 'Gaming', [ka('kp', [4])])])
+        expect(keymapHash(a)).not.toBe(keymapHash(b))
+    })
+
+    it('changes with the active physical layout', () => {
+        const a = km([layer(0, 'Base', [ka('kp', [4])])], 0)
+        const b = km([layer(0, 'Base', [ka('kp', [4])])], 1)
+        expect(keymapHash(a)).not.toBe(keymapHash(b))
+    })
+
+    it('ignores encoder bindings (v1 restores keys only)', () => {
+        const a = km([layer(0, 'Base', [ka('kp', [4])])])
+        const b = km([
+            {
+                ...layer(0, 'Base', [ka('kp', [4])]),
+                encoders: [{ cw: ka('vol', [1]), ccw: ka('vol', [2]) }],
+            },
+        ])
+        expect(keymapHash(a)).toBe(keymapHash(b))
+    })
+})
+
+describe('backupKey', () => {
+    it('prefers the hardware serial', () => {
+        expect(
+            backupKey(svc({ serialNumber: 'SER', name: 'Kbd' }), 'tid'),
+        ).toBe('SER')
+    })
+
+    it('falls back to the transport id, then the name', () => {
+        expect(backupKey(svc({ name: 'Kbd' }), 'tid')).toBe('tid')
+        expect(backupKey(svc({ name: 'Kbd' }), null)).toBe('Kbd')
+    })
+})
+
+describe('buildBackup', () => {
+    it('captures the keymap and computes its hash', () => {
+        const keymap = km([layer(0, 'Base', [ka('kp', [4])])])
+        const b = buildBackup(
+            svc({ serialNumber: 'S', name: 'Kbd' }),
+            keymap,
+            123,
+        )
+        expect(b.keymap).toBe(keymap)
+        expect(b.hash).toBe(keymapHash(keymap))
+        expect(b.savedAt).toBe(123)
+        expect(b.firmware).toBe('zmk')
+    })
+
+    it('records the device identity for cross-host matching', () => {
+        const b = buildBackup(
+            svc({ serialNumber: 'SER', name: 'Kbd', vid: 0x1234, pid: 0x5678 }),
+            km([layer(0, 'Base', [ka('kp', [4])])]),
+            0,
+        )
+        expect(b.serialNumber).toBe('SER')
+        expect(b.vid).toBe(0x1234)
+        expect(b.pid).toBe(0x5678)
+    })
+})
+
+describe('isPortableKey', () => {
+    it('is true when the key is the hardware serial', () => {
+        const b = buildBackup(
+            svc({ serialNumber: 'SER', name: 'Kbd' }),
+            km([layer(0, 'Base', [ka('kp', [4])])]),
+            0,
+        )
+        // backupKey uses the serial when present, so key === serial.
+        expect(isPortableKey('SER', b)).toBe(true)
+    })
+
+    it('is false for a host-local (transport-id / name) fallback key', () => {
+        const b = buildBackup(
+            svc({ name: 'Kbd' }), // no serial → keyed by transport id / name
+            km([layer(0, 'Base', [ka('kp', [4])])]),
+            0,
+        )
+        expect(isPortableKey('/dev/ttyACM0', b)).toBe(false)
+        expect(isPortableKey('Kbd', b)).toBe(false)
+    })
+
+    it('is false when the stored key does not match the recorded serial', () => {
+        const b = buildBackup(
+            svc({ serialNumber: 'SER', name: 'Kbd' }),
+            km([layer(0, 'Base', [ka('kp', [4])])]),
+            0,
+        )
+        expect(isPortableKey('some-other-key', b)).toBe(false)
+    })
+})

--- a/src/renderer/src/stores/profileBackupStore.ts
+++ b/src/renderer/src/stores/profileBackupStore.ts
@@ -1,0 +1,149 @@
+// Pattern check: no GoF pattern (-) — rejected — persisted zustand snapshot map
+// mirroring devicePreviewStore; serializable per-device keymap backup, no abstraction.
+import { create } from 'zustand'
+import { createJSONStorage, devtools, persist } from 'zustand/middleware'
+import type { KeyboardService } from '@firmware/service'
+import type { Keymap } from '@firmware/types'
+
+/**
+ * A restorable snapshot of one keyboard's full keymap, kept in localStorage and
+ * keyed by the device's durable hardware serial (which survives an NVS wipe, so
+ * a reset keyboard still matches its backup on reconnect).
+ */
+// pattern-check: skip — additive optional identity fields on existing interface
+export interface ProfileBackup {
+    deviceName: string
+    firmware: string
+    /** Hardware serial the backup key was derived from, when the device reported
+     *  one. Stored in the value (not just as the map key) so a future account/sync
+     *  layer can match a keyboard across hosts and tell portable backups apart
+     *  from host-local ones. Undefined when the device reports no serial. */
+    serialNumber?: string
+    /** USB vendor/product ids, when known — extra signal for cross-host matching. */
+    vid?: number
+    pid?: number
+    /** Neutral keymap (layers + bindings); restores directly via setKeys. */
+    keymap: Keymap
+    /** Content signature of {@link keymap} — stable across layer-id reassignment
+     *  (hashes names + bindings, not ids), used for wipe/divergence detection. */
+    hash: string
+    /** When set, the user chose "don't ask" for a device whose live keymap hashed
+     *  to this value — suppresses the restore prompt until the live state changes. */
+    dismissedHash?: string
+    savedAt: number
+}
+
+interface ProfileBackupState {
+    backups: Record<string, ProfileBackup>
+    saveBackup: (key: string, backup: ProfileBackup) => void
+    setDismissedHash: (key: string, hash: string) => void
+    clear: (key: string) => void
+}
+
+const useProfileBackupStore = create<ProfileBackupState>()(
+    devtools(
+        persist(
+            (set) => ({
+                backups: {},
+                saveBackup: (key, backup) =>
+                    set((s) => ({
+                        backups: { ...s.backups, [key]: backup },
+                    })),
+                setDismissedHash: (key, hash) =>
+                    set((s) => {
+                        const existing = s.backups[key]
+                        if (!existing) return s
+                        return {
+                            backups: {
+                                ...s.backups,
+                                [key]: { ...existing, dismissedHash: hash },
+                            },
+                        }
+                    }),
+                clear: (key) =>
+                    set((s) => {
+                        const next = { ...s.backups }
+                        delete next[key]
+                        return { backups: next }
+                    }),
+            }),
+            {
+                name: 'profile-backup-store',
+                storage: createJSONStorage(() => localStorage),
+                partialize: (s) => ({ backups: s.backups }),
+            },
+        ),
+    ),
+)
+
+export default useProfileBackupStore
+
+/**
+ * Stable localStorage key for a device's backup. Prefers the hardware serial
+ * (survives an NVS wipe), falling back to the transport id then the reported
+ * name — mirrors devicePreviewStore's key derivation.
+ */
+export function backupKey(
+    service: KeyboardService,
+    lastConnectedId?: string | null,
+): string {
+    return (
+        service.deviceInfo.serialNumber ||
+        lastConnectedId ||
+        service.deviceInfo.name ||
+        'unknown-device'
+    )
+}
+
+/**
+ * Content signature of a keymap that ignores layer ids (which the firmware
+ * reassigns after a wipe or layer add/remove) so a faithful restore hashes equal
+ * to its backup. Covers layer names + every binding's {kind, params} + the active
+ * physical layout. Encoders are intentionally excluded — v1 restores key bindings
+ * only, so hashing them would falsely re-trigger detection after a restore.
+ */
+export function keymapHash(keymap: Keymap): string {
+    const canonical = JSON.stringify({
+        activeLayoutId: keymap.activeLayoutId,
+        layers: keymap.layers.map((l) => ({
+            name: l.name,
+            keys: l.keys.map((k) => [k.kind, k.params]),
+        })),
+    })
+    // djb2 → base36; a short stable string is all detection needs.
+    let h = 5381
+    for (let i = 0; i < canonical.length; i++) {
+        h = ((h << 5) + h + canonical.charCodeAt(i)) | 0
+    }
+    return (h >>> 0).toString(36)
+}
+
+/** Assemble a ProfileBackup from a live keymap read. */
+export function buildBackup(
+    service: KeyboardService,
+    keymap: Keymap,
+    savedAt: number,
+): ProfileBackup {
+    return {
+        deviceName: service.deviceInfo.name || 'Keyboard',
+        firmware: service.deviceInfo.firmware,
+        serialNumber: service.deviceInfo.serialNumber,
+        vid: service.deviceInfo.vid,
+        pid: service.deviceInfo.pid,
+        keymap,
+        hash: keymapHash(keymap),
+        savedAt,
+    }
+}
+
+/**
+ * Whether a backup's map key is portable across hosts — i.e. derived from the
+ * device's hardware serial (`backupKey`'s first branch) rather than a
+ * host-specific transport id / name fallback. A future account/sync layer should
+ * only sync portable backups; host-local ones must be re-keyed on the next local
+ * connect. Note: portability ≠ uniqueness — identical boards with a fixed/blank
+ * firmware serial can still collide on the same key.
+ */
+export function isPortableKey(key: string, backup: ProfileBackup): boolean {
+    return !!backup.serialNumber && key === backup.serialNumber
+}

--- a/src/renderer/src/stores/userSettingsStore.ts
+++ b/src/renderer/src/stores/userSettingsStore.ts
@@ -15,6 +15,11 @@ interface UserSettingsState {
     theme: 'dark' | 'light'
     autosave: boolean
     autoLoadLayout: boolean
+    /** When on, a wiped-but-known keyboard is silently restored from its backup
+     *  on reconnect instead of prompting. See profileBackupStore / restoreProfile. */
+    autoRestoreProfile: boolean
+    /** Transport id of the device flagged to auto-connect on launch, or null. */
+    autoConnectDeviceId: string | null
     keyDisplayMode: Record<string, KeyDisplayMode>
     preferredAdapterCategory: AdapterCategory
     capStyle: CapStyle
@@ -28,6 +33,8 @@ interface UserSettingsState {
     setTheme: (theme: 'dark' | 'light') => void
     setAutosave: (enabled: boolean) => void
     setAutoLoadLayout: (enabled: boolean) => void
+    setAutoRestoreProfile: (enabled: boolean) => void
+    setAutoConnectDeviceId: (id: string | null) => void
     setKeyDisplayMode: (
         firmware: string | undefined,
         mode: KeyDisplayMode,
@@ -43,6 +50,8 @@ const useUserSettingsStore = create<UserSettingsState>()(
                 theme: 'light',
                 autosave: false,
                 autoLoadLayout: false,
+                autoRestoreProfile: false,
+                autoConnectDeviceId: null,
                 keyDisplayMode: {},
                 preferredAdapterCategory: 'zmk',
                 capStyle: 'sculpted',
@@ -58,6 +67,10 @@ const useUserSettingsStore = create<UserSettingsState>()(
                 setAutosave: (enabled) => set({ autosave: enabled }),
                 setAutoLoadLayout: (enabled) =>
                     set({ autoLoadLayout: enabled }),
+                setAutoRestoreProfile: (enabled) =>
+                    set({ autoRestoreProfile: enabled }),
+                setAutoConnectDeviceId: (id) =>
+                    set({ autoConnectDeviceId: id }),
                 setKeyDisplayMode: (firmware, mode) =>
                     set((s) => ({
                         keyDisplayMode: {
@@ -79,7 +92,7 @@ const useUserSettingsStore = create<UserSettingsState>()(
             {
                 name: 'user-settings-store',
                 storage: createJSONStorage(() => localStorage),
-                version: 7,
+                version: 8,
                 migrate: (persisted: unknown, version: number) => {
                     if (!persisted || typeof persisted !== 'object') {
                         return persisted as Partial<UserSettingsState>
@@ -144,6 +157,16 @@ const useUserSettingsStore = create<UserSettingsState>()(
                         // explored the builder, so don't surface it to them.
                         if (typeof p.seenBuilderTour !== 'boolean') {
                             p.seenBuilderTour = true
+                        }
+                    }
+                    if (version < 8) {
+                        // Profile auto-restore + per-device auto-connect. Both
+                        // default off / unset for existing users.
+                        if (typeof p.autoRestoreProfile !== 'boolean') {
+                            p.autoRestoreProfile = false
+                        }
+                        if (typeof p.autoConnectDeviceId !== 'string') {
+                            p.autoConnectDeviceId = null
                         }
                     }
                     return p as Partial<UserSettingsState>


### PR DESCRIPTION
Four independent features (each its own commit).

## 1 · Support this project
Header + start-page Heart button opens a dialog listing donation platforms (GitHub Sponsors, Ko-fi). Links open in the system browser in both web and Electron. Open Collective row is scaffolded but commented out.
- ⚠️ **Confirm the real Ko-fi handle** in `src/renderer/src/lib/constants.ts` (`KOFI_URL` is currently a placeholder). GitHub Sponsors URL derives from the repo owner.

## 2 · Discord release announcement
New `.github/workflows/discord-release.yml` fires on `release: published`, posts a rich embed (version + notes + links) built safely with `jq`. Truncates long changelogs, skips prereleases, no-ops if the secret is missing.
- ⚠️ **Requires a `DISCORD_WEBHOOK_URL` secret** + a Discord channel webhook (manual setup; see PR discussion / repo notes).

## 3 · Profile backup & restore (generalized; ZMK-only enabled)
Captures each keyboard's keymap to localStorage (keyed by hardware serial, which survives an NVS wipe) on connect and after every save. On reconnect with a diverged/wiped layout it prompts to restore — or restores silently when the new **Auto-restore profile** setting is on. Manual "Restore backup" in the device menu too.
- Firmware-neutral: runs entirely on `getKeymap`/`setKeys`/`commit`, gated on **`capabilities.profileRestore`** — set only for ZMK for now.
- **Depends on Wolffyx/remapprClientFirmware#80** (adds the capability flag). That must land / be on the CI ref for this PR's typecheck to pass.
- Backups also record `serialNumber`/`vid`/`pid` + an `isPortableKey()` helper to future-proof a cross-host account/sync layer.
- v1 restores key bindings only (no encoders). HW-verify pending.

## 4 · Auto-connect
Per-device "Auto-connect on launch" toggle in the device menu persists a single `autoConnectDeviceId`. A one-shot launch effect reconnects the flagged granted device with no permission prompt. A module-level guard prevents auto-reconnecting right after a manual disconnect.

## Verification
typecheck (web+node) ✓ · lint ✓ · 1139 tests ✓ (16 new for the backup store + restore orchestration).